### PR TITLE
General fixes, cleaned up code, and preventing people from being dumb

### DIFF
--- a/Source/Core/Core/BootManager.cpp
+++ b/Source/Core/Core/BootManager.cpp
@@ -255,13 +255,6 @@ bool BootCore(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
     return false;
   }
 
-  // Block running if no UserID
-  if (!StartUp.UserHasUserID())
-  {
-    PanicAlertT("You do not have a User ID or you have not placed your User.json file in the correct location.\nPlease go to https://www.projectrio.online and follow the instructions to create an account.");
-    return false;
-  }
-
   // Load game specific settings
   if (!std::holds_alternative<BootParameters::IPL>(boot->parameters))
   {

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -64,7 +64,7 @@ SConfig::SConfig()
   LoadDefaults();
   // Make sure we have log manager
   LoadSettings();
-  LoadLocalSettings();
+  //LoadLocalSettings();
 }
 
 void SConfig::Init()
@@ -393,7 +393,7 @@ void SConfig::LoadSettings()
   LoadAutoUpdateSettings(ini);
   LoadJitDebugSettings(ini);
 }
-
+/*
 void SConfig::LoadLocalSettings()
 {
   Config::Load();
@@ -404,7 +404,7 @@ void SConfig::LoadLocalSettings()
 
   LoadLocalPlayerSettings(ini);
 }
-
+*/
 void SConfig::LoadGeneralSettings(IniFile& ini)
 {
   IniFile::Section* general = ini.GetOrCreateSection("General");
@@ -661,7 +661,7 @@ void SConfig::LoadJitDebugSettings(IniFile& ini)
   section->Get("JitBranchOff", &bJITBranchOff, false);
   section->Get("JitRegisterCacheOff", &bJITRegisterCacheOff, false);
 }
-
+/*
 void SConfig::LoadLocalPlayerSettings(IniFile& ini)
 {
   IniFile::Section* localplayers = ini.GetOrCreateSection("Local_Players");
@@ -671,7 +671,7 @@ void SConfig::LoadLocalPlayerSettings(IniFile& ini)
   localplayers->Set("Player 3", m_local_player_reset);
   localplayers->Set("Player 4", m_local_player_reset);
 }
-
+*/
 void SConfig::ResetRunningGameMetadata()
 {
   SetRunningGameMetadata("00000000", "", 0, 0, DiscIO::Region::Unknown);

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -64,7 +64,6 @@ SConfig::SConfig()
   LoadDefaults();
   // Make sure we have log manager
   LoadSettings();
-  //LoadLocalSettings();
 }
 
 void SConfig::Init()
@@ -393,18 +392,7 @@ void SConfig::LoadSettings()
   LoadAutoUpdateSettings(ini);
   LoadJitDebugSettings(ini);
 }
-/*
-void SConfig::LoadLocalSettings()
-{
-  Config::Load();
 
-  INFO_LOG_FMT(BOOT, "Loading Settings from {}", File::GetUserPath(F_LOCALPLAYERSCONFIG_IDX));
-  IniFile ini;
-  ini.Load(File::GetUserPath(F_LOCALPLAYERSCONFIG_IDX));
-
-  LoadLocalPlayerSettings(ini);
-}
-*/
 void SConfig::LoadGeneralSettings(IniFile& ini)
 {
   IniFile::Section* general = ini.GetOrCreateSection("General");
@@ -661,17 +649,7 @@ void SConfig::LoadJitDebugSettings(IniFile& ini)
   section->Get("JitBranchOff", &bJITBranchOff, false);
   section->Get("JitRegisterCacheOff", &bJITRegisterCacheOff, false);
 }
-/*
-void SConfig::LoadLocalPlayerSettings(IniFile& ini)
-{
-  IniFile::Section* localplayers = ini.GetOrCreateSection("Local_Players");
 
-  localplayers->Set("Player 1", m_local_player_reset);
-  localplayers->Set("Player 2", m_local_player_reset);
-  localplayers->Set("Player 3", m_local_player_reset);
-  localplayers->Set("Player 4", m_local_player_reset);
-}
-*/
 void SConfig::ResetRunningGameMetadata()
 {
   SetRunningGameMetadata("00000000", "", 0, 0, DiscIO::Region::Unknown);

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -1103,12 +1103,6 @@ bool SConfig::GameHasDefaultGameIni(const std::string& id, u16 revision)
 	});
 }
 
-
-bool SConfig::UserHasUserID()
-{
-  return File::Exists(File::GetExeDirectory() + DIR_SEP + "User.json");
-}
-
 IniFile SConfig::LoadDefaultGameIni(const std::string& id, std::optional<u16> revision)
 {
   IniFile game_ini;

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -326,8 +326,6 @@ struct SConfig
   std::string m_local_player_3{"No Player Selected"};
   std::string m_local_player_4{"No Player Selected"};
   
-  //std::string m_local_player_reset = "No Player Selected";
-
   SConfig(const SConfig&) = delete;
   SConfig& operator=(const SConfig&) = delete;
   SConfig(SConfig&&) = delete;
@@ -339,7 +337,6 @@ struct SConfig
 
   // Load settings
   void LoadSettings();
-  //void LoadLocalSettings();
 
   // Return the permanent and somewhat globally used instance of this struct
   static SConfig& GetInstance() { return (*m_Instance); }
@@ -363,14 +360,12 @@ private:
   void SaveAutoUpdateSettings(IniFile& ini);
   void SaveJitDebugSettings(IniFile& ini);
   void SaveLocalPlayerSettings(IniFile& ini);
-
   void LoadGeneralSettings(IniFile& ini);
   void LoadInterfaceSettings(IniFile& ini);
   void LoadGameListSettings(IniFile& ini);
   void LoadCoreSettings(IniFile& ini);
   void LoadDSPSettings(IniFile& ini);
   void LoadInputSettings(IniFile& ini);
-  //void LoadLocalPlayerSettings(IniFile& ini);
   void LoadMovieSettings(IniFile& ini);
   void LoadFifoPlayerSettings(IniFile& ini);
   void LoadBluetoothPassthroughSettings(IniFile& ini);

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -320,13 +320,13 @@ struct SConfig
   // Auto-update settings
   std::string m_auto_update_track;
   std::string m_auto_update_hash_override;
-
+  
   std::string m_local_player_1{"No Player Selected"};
   std::string m_local_player_2{"No Player Selected"};
   std::string m_local_player_3{"No Player Selected"};
   std::string m_local_player_4{"No Player Selected"};
-
-  std::string m_local_player_reset = "No Player Selected";
+  
+  //std::string m_local_player_reset = "No Player Selected";
 
   SConfig(const SConfig&) = delete;
   SConfig& operator=(const SConfig&) = delete;
@@ -339,7 +339,7 @@ struct SConfig
 
   // Load settings
   void LoadSettings();
-  void LoadLocalSettings();
+  //void LoadLocalSettings();
 
   // Return the permanent and somewhat globally used instance of this struct
   static SConfig& GetInstance() { return (*m_Instance); }
@@ -370,7 +370,7 @@ private:
   void LoadCoreSettings(IniFile& ini);
   void LoadDSPSettings(IniFile& ini);
   void LoadInputSettings(IniFile& ini);
-  void LoadLocalPlayerSettings(IniFile& ini);
+  //void LoadLocalPlayerSettings(IniFile& ini);
   void LoadMovieSettings(IniFile& ini);
   void LoadFifoPlayerSettings(IniFile& ini);
   void LoadBluetoothPassthroughSettings(IniFile& ini);

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -223,9 +223,6 @@ struct SConfig
   IniFile LoadLocalGameIni() const;
   IniFile LoadGameIni() const;
 
-  void GetLocalPlayerSettings(IniFile& ini);
-
-  static bool UserHasUserID();
   static bool GameHasDefaultGameIni(const std::string& id, u16 revision);
   static IniFile LoadDefaultGameIni(const std::string& id, std::optional<u16> revision);
   static IniFile LoadLocalGameIni(const std::string& id, std::optional<u16> revision);
@@ -380,7 +377,6 @@ private:
   void LoadUSBPassthroughSettings(IniFile& ini);
   void LoadAutoUpdateSettings(IniFile& ini);
   void LoadJitDebugSettings(IniFile& ini);
-  void LoadUserIDSettings(IniFile& ini);
 
   void SetRunningGameMetadata(const std::string& game_id, const std::string& gametdb_id,
                               u64 title_id, u16 revision, DiscIO::Region region);

--- a/Source/Core/Core/GeckoCode.cpp
+++ b/Source/Core/Core/GeckoCode.cpp
@@ -68,7 +68,7 @@ void SetActiveCodes(const std::vector<GeckoCode>& gcodes)
   std::lock_guard lk(s_active_codes_lock);
 
   s_active_codes.clear();
-  if (SConfig::GetInstance().bEnableCheats)
+  if (true)
   {
     s_active_codes.reserve(gcodes.size());
     std::copy_if(gcodes.begin(), gcodes.end(), std::back_inserter(s_active_codes),
@@ -100,7 +100,7 @@ std::vector<GeckoCode> SetAndReturnActiveCodes(const std::vector<GeckoCode>& gco
   std::lock_guard lk(s_active_codes_lock);
 
   s_active_codes.clear();
-  if (SConfig::GetInstance().bEnableCheats)
+  if (true)
   {
     s_active_codes.reserve(gcodes.size());
     std::copy_if(gcodes.begin(), gcodes.end(), std::back_inserter(s_active_codes),
@@ -231,9 +231,6 @@ void Shutdown()
 
 void RunCodeHandler()
 {
-  if (!SConfig::GetInstance().bEnableCheats)
-    return;
-
   // NOTE: Need to release the lock because of GUI deadlocks with PanicAlert in HostWrite_*
   {
     std::lock_guard codes_lock(s_active_codes_lock);

--- a/Source/Core/DolphinQt/Config/CheatWarningWidget.cpp
+++ b/Source/Core/DolphinQt/Config/CheatWarningWidget.cpp
@@ -66,13 +66,6 @@ void CheatWarningWidget::Update(bool running)
     m_text->setText(tr("Changing cheats will only take effect when the game is restarted."));
   }
 
-  if (!Settings::Instance().GetCheatsEnabled())
-  {
-    hide_widget = false;
-    hide_config_button = false;
-    m_text->setText(tr("Dolphin's cheat system is currently disabled."));
-  }
-
   setHidden(hide_widget);
   m_config_button->setHidden(hide_config_button);
 }

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
@@ -292,10 +292,14 @@ void GeckoCodeWidget::UpdateList()
                    Qt::ItemIsDragEnabled);
     item->setCheckState(code.enabled ? Qt::Checked : Qt::Unchecked);
     item->setData(Qt::UserRole, static_cast<int>(i));
+    // stop people from being dumb and disabling the required codeset
+    if (code.name == "! Required: Project Rio Codes !")
+    {
+      item->setCheckState(Qt::Checked);
+    }
 
     m_code_list->addItem(item);
   }
-
   m_code_list->setDragDropMode(QAbstractItemView::InternalMove);
 }
 

--- a/Source/Core/DolphinQt/Config/LocalPlayersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/LocalPlayersWidget.cpp
@@ -25,7 +25,6 @@
 #include "Core/LocalPlayersConfig.h"
 #include "DolphinQt/Config/AddLocalPlayers.h"
 
-#include "Common/MsgHandler.h"
 #include "Core/ConfigManager.h"
 #include "Core/Core.h"
 #include "Core/HW/SI/SI.h"

--- a/Source/Core/DolphinQt/Config/LocalPlayersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/LocalPlayersWidget.cpp
@@ -36,14 +36,12 @@
 LocalPlayersWidget::LocalPlayersWidget(QWidget* parent) : QWidget(parent)
 {
   CreateLayout();
-  LoadPlayers();
   ConnectWidgets();
 
   IniFile local_players_ini;
   local_players_ini.Load(File::GetUserPath(F_LOCALPLAYERSCONFIG_IDX));
   m_local_players = AddPlayers::LoadPlayers(local_players_ini);
-
-  UpdatePlayers();
+  LoadPlayers();
 }
 
 void LocalPlayersWidget::CreateLayout()
@@ -107,28 +105,7 @@ void LocalPlayersWidget::UpdatePlayers()
   m_player_list_3->clear();
   m_player_list_4->clear();
 
-  // List an option to not select a player
-  m_player_list_1->addItem(tr("No Player Selected"));
-  m_player_list_2->addItem(tr("No Player Selected"));
-  m_player_list_3->addItem(tr("No Player Selected"));
-  m_player_list_4->addItem(tr("No Player Selected"));
-
-  // List avalable players in LocalPlayers.ini
-  for (size_t i = 0; i < m_local_players.size(); i++)
-  {
-    const auto& player = m_local_players[i];
-
-    auto username = QString::fromStdString(player.username)
-                                         .replace(QStringLiteral("&lt;"), QChar::fromLatin1('<'))
-                                         .replace(QStringLiteral("&gt;"), QChar::fromLatin1('>'));
-
-    // In the future, i should add in a feature that if a player is selected on another port, they won't appear on the dropdown
-    // some conditional that checks the other ports before adding the item
-    m_player_list_1->addItem(username);
-    m_player_list_2->addItem(username);
-    m_player_list_3->addItem(username);
-    m_player_list_4->addItem(username);
-  }
+  LoadPlayers();
 }
 
 void LocalPlayersWidget::OnAddPlayers()
@@ -161,11 +138,31 @@ void LocalPlayersWidget::SavePlayers()
 
 void LocalPlayersWidget::LoadPlayers()
 {
-  // do this so that no players are selected upon loading Rio for the first time. prevent accidental stat recording for players
-  m_player_list_1->setCurrentIndex(0);
-  m_player_list_2->setCurrentIndex(0);
-  m_player_list_3->setCurrentIndex(0);
-  m_player_list_4->setCurrentIndex(0);
+
+
+  // List an option to not select a player
+  m_player_list_1->addItem(tr("No Player Selected"));
+  m_player_list_2->addItem(tr("No Player Selected"));
+  m_player_list_3->addItem(tr("No Player Selected"));
+  m_player_list_4->addItem(tr("No Player Selected"));
+
+  // List avalable players in LocalPlayers.ini
+  for (size_t i = 0; i < m_local_players.size(); i++)
+  {
+    const auto& player = m_local_players[i];
+
+    auto username = QString::fromStdString(player.username)
+                        .replace(QStringLiteral("&lt;"), QChar::fromLatin1('<'))
+                        .replace(QStringLiteral("&gt;"), QChar::fromLatin1('>'));
+
+    // In the future, i should add in a feature that if a player is selected on another port, they
+    // won't appear on the dropdown some conditional that checks the other ports before adding the
+    // item
+    m_player_list_1->addItem(username);
+    m_player_list_2->addItem(username);
+    m_player_list_3->addItem(username);
+    m_player_list_4->addItem(username);
+  }
 }
 
 void LocalPlayersWidget::ConnectWidgets()

--- a/Source/Core/DolphinQt/Config/LocalPlayersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/LocalPlayersWidget.cpp
@@ -35,13 +35,12 @@
 
 LocalPlayersWidget::LocalPlayersWidget(QWidget* parent) : QWidget(parent)
 {
-  CreateLayout();
-  ConnectWidgets();
-
   IniFile local_players_ini;
   local_players_ini.Load(File::GetUserPath(F_LOCALPLAYERSCONFIG_IDX));
   m_local_players = AddPlayers::LoadPlayers(local_players_ini);
+  CreateLayout();
   LoadPlayers();
+  ConnectWidgets();
 }
 
 void LocalPlayersWidget::CreateLayout()
@@ -105,6 +104,30 @@ void LocalPlayersWidget::UpdatePlayers()
   m_player_list_3->clear();
   m_player_list_4->clear();
 
+  // List an option to not select a player
+  m_player_list_1->addItem(tr("No Player Selected"));
+  m_player_list_2->addItem(tr("No Player Selected"));
+  m_player_list_3->addItem(tr("No Player Selected"));
+  m_player_list_4->addItem(tr("No Player Selected"));
+
+  // List avalable players in LocalPlayers.ini
+  for (size_t i = 0; i < m_local_players.size(); i++)
+  {
+    const auto& player = m_local_players[i];
+
+    auto username = QString::fromStdString(player.username)
+                        .replace(QStringLiteral("&lt;"), QChar::fromLatin1('<'))
+                        .replace(QStringLiteral("&gt;"), QChar::fromLatin1('>'));
+
+    // In the future, i should add in a feature that if a player is selected on another port, they
+    // won't appear on the dropdown some conditional that checks the other ports before adding the
+    // item
+    m_player_list_1->addItem(username);
+    m_player_list_2->addItem(username);
+    m_player_list_3->addItem(username);
+    m_player_list_4->addItem(username);
+  }
+
   LoadPlayers();
 }
 
@@ -138,14 +161,6 @@ void LocalPlayersWidget::SavePlayers()
 
 void LocalPlayersWidget::LoadPlayers()
 {
-
-
-  // List an option to not select a player
-  m_player_list_1->addItem(tr("No Player Selected"));
-  m_player_list_2->addItem(tr("No Player Selected"));
-  m_player_list_3->addItem(tr("No Player Selected"));
-  m_player_list_4->addItem(tr("No Player Selected"));
-
   // List avalable players in LocalPlayers.ini
   for (size_t i = 0; i < m_local_players.size(); i++)
   {
@@ -163,10 +178,21 @@ void LocalPlayersWidget::LoadPlayers()
     m_player_list_3->addItem(username);
     m_player_list_4->addItem(username);
   }
+
+  m_player_list_1->setCurrentIndex(m_player_list_1->findText(QString::fromStdString(SConfig::GetInstance().m_local_player_1)));
+  m_player_list_2->setCurrentIndex(m_player_list_2->findText(QString::fromStdString(SConfig::GetInstance().m_local_player_2)));
+  m_player_list_3->setCurrentIndex(m_player_list_3->findText(QString::fromStdString(SConfig::GetInstance().m_local_player_3)));
+  m_player_list_4->setCurrentIndex(m_player_list_4->findText(QString::fromStdString(SConfig::GetInstance().m_local_player_4)));
+
+  // List an option to not select a player
+  m_player_list_1->addItem(tr("No Player Selected"));
+  m_player_list_2->addItem(tr("No Player Selected"));
+  m_player_list_3->addItem(tr("No Player Selected"));
+  m_player_list_4->addItem(tr("No Player Selected"));
 }
 
 void LocalPlayersWidget::ConnectWidgets()
-{          
+{ 
   connect(m_player_list_1, qOverload<int>(&QComboBox::currentIndexChanged), this,
           [=](int index) { Settings::Instance().SetPlayerOne(m_player_list_1->itemText(index)); });
   connect(
@@ -176,7 +202,7 @@ void LocalPlayersWidget::ConnectWidgets()
           [=](int index) { Settings::Instance().SetPlayerThree(m_player_list_3->itemText(index)); });
   connect(m_player_list_4, qOverload<int>(&QComboBox::currentIndexChanged), this,
           [=](int index) { Settings::Instance().SetPlayerFour(m_player_list_4->itemText(index)); });
-
+  
   connect(m_player_list_1, qOverload<int>(&QComboBox::currentIndexChanged), this,
           &LocalPlayersWidget::SavePlayers);
   connect(m_player_list_2, qOverload<int>(&QComboBox::currentIndexChanged), this,

--- a/Source/Core/DolphinQt/Config/LocalPlayersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/LocalPlayersWidget.cpp
@@ -58,10 +58,10 @@ void LocalPlayersWidget::CreateLayout()
 
   auto* gc_label3 = new QLabel(tr("Player 3"));
   auto gc_box3 = m_player_list_3 = new QComboBox();
-
+  
   auto* gc_label4 = new QLabel(tr("Player 4"));
   auto gc_box4 = m_player_list_4 = new QComboBox();
-
+ 
   m_player_layout->addWidget(gc_label1, 0, 0);
   m_player_layout->addWidget(gc_box1, 0, 1);
   m_player_layout->addWidget(gc_label2, 1, 0);
@@ -161,6 +161,12 @@ void LocalPlayersWidget::SavePlayers()
 
 void LocalPlayersWidget::LoadPlayers()
 {
+  // List an option to not select a player
+  m_player_list_1->addItem(tr("No Player Selected"));
+  m_player_list_2->addItem(tr("No Player Selected"));
+  m_player_list_3->addItem(tr("No Player Selected"));
+  m_player_list_4->addItem(tr("No Player Selected"));
+
   // List avalable players in LocalPlayers.ini
   for (size_t i = 0; i < m_local_players.size(); i++)
   {
@@ -178,17 +184,11 @@ void LocalPlayersWidget::LoadPlayers()
     m_player_list_3->addItem(username);
     m_player_list_4->addItem(username);
   }
-
+  /*
   m_player_list_1->setCurrentIndex(m_player_list_1->findText(QString::fromStdString(SConfig::GetInstance().m_local_player_1)));
   m_player_list_2->setCurrentIndex(m_player_list_2->findText(QString::fromStdString(SConfig::GetInstance().m_local_player_2)));
   m_player_list_3->setCurrentIndex(m_player_list_3->findText(QString::fromStdString(SConfig::GetInstance().m_local_player_3)));
-  m_player_list_4->setCurrentIndex(m_player_list_4->findText(QString::fromStdString(SConfig::GetInstance().m_local_player_4)));
-
-  // List an option to not select a player
-  m_player_list_1->addItem(tr("No Player Selected"));
-  m_player_list_2->addItem(tr("No Player Selected"));
-  m_player_list_3->addItem(tr("No Player Selected"));
-  m_player_list_4->addItem(tr("No Player Selected"));
+  m_player_list_4->setCurrentIndex(m_player_list_4->findText(QString::fromStdString(SConfig::GetInstance().m_local_player_4)));*/
 }
 
 void LocalPlayersWidget::ConnectWidgets()

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -283,8 +283,6 @@ MainWindow::~MainWindow()
   Settings::Instance().ResetNetPlayClient();
   Settings::Instance().ResetNetPlayServer();
 
-  ResetLocalPlayers();
-
   delete m_render_widget;
   delete m_netplay_dialog;
 
@@ -552,12 +550,6 @@ void MainWindow::ConnectMenuBar()
     m_code_widget->UpdateSymbols();
     m_code_widget->Update();
   });
-}
-
-void MainWindow::ResetLocalPlayers()
-{
-  SConfig& settings = SConfig::GetInstance();
-  settings.LoadLocalSettings();
 }
 
 void MainWindow::ConnectHotkeys()

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -117,7 +117,6 @@ private:
   void ConnectGameList();
   void ConnectHost();
   void ConnectHotkeys();
-  void ResetLocalPlayers();
   void ConnectMenuBar();
   void ConnectRenderWidget();
   void ConnectStack();

--- a/Source/Core/DolphinQt/Settings/GeneralPane.cpp
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.cpp
@@ -83,7 +83,6 @@ void GeneralPane::OnEmulationStateChanged(Core::State state)
   const bool running = state != Core::State::Uninitialized;
 
   m_checkbox_dualcore->setEnabled(!running);
-  m_checkbox_cheats->setEnabled(!running);
   m_checkbox_override_region_settings->setEnabled(!running);
 #ifdef USE_DISCORD_PRESENCE
   m_checkbox_discord_presence->setEnabled(!running);
@@ -94,7 +93,6 @@ void GeneralPane::OnEmulationStateChanged(Core::State state)
 void GeneralPane::ConnectLayout()
 {
   connect(m_checkbox_dualcore, &QCheckBox::toggled, this, &GeneralPane::OnSaveConfig);
-  connect(m_checkbox_cheats, &QCheckBox::toggled, this, &GeneralPane::OnSaveConfig);
   connect(m_checkbox_override_region_settings, &QCheckBox::stateChanged, this,
           &GeneralPane::OnSaveConfig);
   connect(m_checkbox_auto_disc_change, &QCheckBox::toggled, this, &GeneralPane::OnSaveConfig);
@@ -135,9 +133,6 @@ void GeneralPane::CreateBasic()
 
   m_checkbox_dualcore = new QCheckBox(tr("Enable Dual Core (speedup)"));
   basic_group_layout->addWidget(m_checkbox_dualcore);
-
-  m_checkbox_cheats = new QCheckBox(tr("Enable Cheats"));
-  basic_group_layout->addWidget(m_checkbox_cheats);
 
   m_checkbox_override_region_settings = new QCheckBox(tr("Allow Mismatched Region Settings"));
   basic_group_layout->addWidget(m_checkbox_override_region_settings);
@@ -255,7 +250,6 @@ void GeneralPane::LoadConfig()
   m_checkbox_enable_analytics->setChecked(Settings::Instance().IsAnalyticsEnabled());
 #endif
   m_checkbox_dualcore->setChecked(SConfig::GetInstance().bCPUThread);
-  m_checkbox_cheats->setChecked(Settings::Instance().GetCheatsEnabled());
   m_checkbox_override_region_settings->setChecked(SConfig::GetInstance().bOverrideRegionSettings);
   m_checkbox_auto_disc_change->setChecked(Config::Get(Config::MAIN_AUTO_DISC_CHANGE));
 #ifdef USE_DISCORD_PRESENCE
@@ -349,12 +343,10 @@ void GeneralPane::OnSaveConfig()
 #endif
   settings.bCPUThread = m_checkbox_dualcore->isChecked();
   Config::SetBaseOrCurrent(Config::MAIN_CPU_THREAD, m_checkbox_dualcore->isChecked());
-  Settings::Instance().SetCheatsEnabled(m_checkbox_cheats->isChecked());
   settings.bOverrideRegionSettings = m_checkbox_override_region_settings->isChecked();
   Config::SetBaseOrCurrent(Config::MAIN_OVERRIDE_REGION_SETTINGS,
                            m_checkbox_override_region_settings->isChecked());
   Config::SetBase(Config::MAIN_AUTO_DISC_CHANGE, m_checkbox_auto_disc_change->isChecked());
-  Config::SetBaseOrCurrent(Config::MAIN_ENABLE_CHEATS, m_checkbox_cheats->isChecked());
   settings.m_EmulationSpeed = m_combobox_speedlimit->currentIndex() * 0.1f;
   Settings::Instance().SetFallbackRegion(
       UpdateFallbackRegionFromIndex(m_combobox_fallback_region->currentIndex()));

--- a/Source/Core/DolphinQt/Settings/GeneralPane.h
+++ b/Source/Core/DolphinQt/Settings/GeneralPane.h
@@ -28,7 +28,6 @@ private:
   void CreateLayout();
   void ConnectLayout();
   void CreateBasic();
-  void CreateAutoUpdate();
   void CreateFallbackRegion();
 
   void LoadConfig();


### PR DESCRIPTION
Due to a change of plans, we'll no longer use the User.json system, so i've removed the code that prevents loading without one.

I've also made it so that cheats are always enabled, regardless of user configurations. The checkbox for enabling cheats is not present. This is to prevent people from causing issues down the line when playing online without cheats enabled for example. Project Rio also now re-enables the required codeset as another anti-dumb prevention measure

I've also made a few general fixes to the local players system. I've mostly just cleaned up some code. The system still works as it did previously.

Lastly, i removed the auto updater from the config menu. Since we've already disabled auto updates, it was both unnecessary to have and it could lead to future confusion that Project Rio will be auto updated.