### PR TITLE
Updated and Commented default codeset; fixed some typos

### DIFF
--- a/Data/Sys/GameSettings/GYQE01.ini
+++ b/Data/Sys/GameSettings/GYQE01.ini
@@ -2,15 +2,15 @@
 $! ReadMe !
 00000000 00000000
 *Thanks for Downloading Project Rio! There's a few things to know:
-*- To obtain all of our mods, use the "Download Codes" button (only works in Project Rio)
+*- To obtain all of our mods, use the "Download Codes" button (only works in Project Rio).
 *- Netplay Event Code 3.1 is used to easily set up online games. It contains all of our community mods, which are Unlock Everything, Unlimited Extra Innings, Boot to Main Menu, Manual Fielder Select, Anti Quick Pitch, and Default Competitive Rules.
-*- Do not enable this code
+*- Do not enable this code.
 *
 *That's all -- have fun! Join our Discord to play ranked online games and talk more Mario Superstar Baseball https://discord.com/invite/9ZZtpuEPCd
 * 
 *~PeacockSlayer and LittleCoaks
 $! Required: Project Rio Codes ! [PeacockSlayer, LittleCoaks]
-C2042C4C 00000008
+C2042C4C 00000008 #Generate the Game ID at 0x802EBF90 when Start Game is pressed, unless duplicate characters is enabled [LittleCoaks]
 90010014 3D20803C
 61296726 89290000
 3CE08035 60E730F7
@@ -19,19 +19,19 @@ C2042C4C 00000008
 3CE0802E 60E7BF90
 7D2C42E6 91270000
 60000000 00000000
-c26ed704 00000003
+c26ed704 00000003 #Clear Game ID when returning to main menu after game ends [LittleCoaks]
 981f01d2 3d00802e
 6108bf90 91280000
 60000000 00000000
-c269ab2c 00000003
+c269ab2c 00000003 #Clear Game ID when exiting mid-game [LittleCoaks]
 98050125 3e40802e
 6252bf90 92320000
 60000000 00000000
-c26bbf88 00000003
+c26bbf88 00000003 #Clear hit result after each pitch [PeacockSlayer]
 99090037 3ea08089
 62b53baa 99150000
 3aa00000 00000000
-203a153c 00860000
+203a153c 00860000 #Store Port Info->0x802EBF94 (fielding port) and 0x802EBF95 (batting port) [LittleCoaks]
 c2699728 00000003
 90030008 3dc0802e
 61cebf96 39e00000
@@ -50,7 +50,7 @@ C26B4654 00000008
 3A100001 9A0E0001
 60000000 00000000
 e2000001 00000000
-c20540b0 00000002
+c20540b0 00000002 #Mushroom Icon on CSS [LittleCoaks]
 3c000004 9004005c
 38000000 00000000
 c2053a60 00000002
@@ -59,19 +59,22 @@ c2053a60 00000002
 c2053afc 00000002
 3c000004 9004005c
 38000000 00000000
-*Do not disable this code. This code is necessary for the basic functionality of Project Rio features
+00366177 00000001 #Enable Controller Rumble [LittleCoaks]
+*Do not disable this code. This code is necessary for the basic functionality of Project Rio features.
 *
-*As a visual queue that this code is active, the top left of the screen after selecting "Exhibition Game" will display a mushroom
+*As a visual queue that this code is active, the top left of the screen after selecting "Exhibition Game" will display a mushroom.
+*
+*This code automatically enables controller rumble. If you want to disable rumble, turn off rumble in Dolphin's controller settings.
 $!! Netplay Event Code 3.1 !![PeacockSlayer, LittleCoaks]
-280e877d 00000000
+280e877d 00000000 #Boot to Main Menu [LittleCoaks]
 0463f964 38600005
 e2000001 00000000
-04699a10 380400f6
-000e870e 00000002
+04699a10 380400f6 #Unlimited Extra Innings [LittleCoaks]
+000e870e 00000002 #Unlock Everything [PeacockSlayer, LittleCoaks]
 00361c15 00000001
 000e8716 00050001
 00361b20 00350001
-c267ac00 00000041
+c267ac00 00000041 #Manual Fielder Select [PeacockSlayer, LittleCoaks]
 b0050148 3f408067
 635aac04 7f4903a6
 3e408023 3a526d30
@@ -225,14 +228,15 @@ c2692224 00000008
 0423da60 00010203
 0423da64 05040607
 0023da68 00000008
-C26B406C 00000004
+C26B406C 00000004 #Anti Quick Pitch [PeacockSlayer, LittleCoaks]
 38000000 3DC08089
 61CE099D 89CE0000
 2C0E0001 41820008
 A01E0006 00000000
-040498d8 9BE7003E
+040498d8 9BE7003E #Default Competitive Rules [LittleCoaks]
 040498dc 9867003F
-*Contains the following codes: Manual Fielder Select 2.0, Boot to Main Menu, Unlimited Extra Innings, Unlock Everything, Anti Quick Pitch, Default Competitive Rules.
+003C50E8 00000001 #Skip Memory Card Check on Main Menu [LittleCoaks]
+*Contains the following codes: Manual Fielder Select 2.0, Boot to Main Menu, Unlimited Extra Innings, Unlock Everything, Anti Quick Pitch, Default Competitive Rules, Skip Memory Card Check on Main Menu.
 *
 *Controls for Manual Fielder Select:
 *Y->                     <-X
@@ -241,10 +245,10 @@ A01E0006 00000000
 *Z+Y: SS
 *Z+X: 2nd
 $!! Batter Lag Reduction !![LittleCoaks]
-28890976 00000001
+28890976 00000001 #Removes first frame of a batter's swing
 00890977 00000002
 e2000001 00000000
-2289091c 00000000
+2289091c 00000000 #Adds 1 to the "frame of contact of pitch" addresss
 c2652360 00000003
 a8031b68 38a0ffff
 2c000fff 41810008

--- a/Source/Core/DolphinQt/Config/PropertiesDialog.cpp
+++ b/Source/Core/DolphinQt/Config/PropertiesDialog.cpp
@@ -92,7 +92,7 @@ GeckoDialog::GeckoDialog(QWidget* parent)
     : QDialog(parent)
 {
   setWindowTitle(QStringLiteral("%1 - %2")
-                     .arg(QString::fromStdString("Mario Superstar Baseball Gecko Codes"), QString::fromStdString("(Game ID: GYQE01")));
+                     .arg(QString::fromStdString("Mario Superstar Baseball Gecko Codes"), QString::fromStdString("(Game ID: GYQE01)")));
   setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
   QVBoxLayout* layout = new QVBoxLayout();

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -103,7 +103,7 @@ void NetPlayDialog::CreateMainLayout()
   m_start_button = new QPushButton(tr("Start"));
   m_buffer_size_box = new QSpinBox;
   m_buffer_size_box->setToolTip(
-      tr("Set the buffer based on the ping. The buffer should be ping ÷ 8 (rounded up).\nFor a simple method, "
+      tr("Set the buffer based on the ping. The buffer should be ping ÷ 8 (rounded up).\n\nEnabling the \"Batter Lag Reduction\" Gecko Code removes 1 frame (4 buffer) from swings.\n\nFor a simple method, "
          "use 8 for 64 ping and less, 12 for 100 ping and less, and 16 for 150 ping and "
          "less.\nGames above 150 ping will be very laggy and are not recommended for competitive "
          "play."));
@@ -113,7 +113,7 @@ void NetPlayDialog::CreateMainLayout()
   m_menu_bar = new QMenuBar(this);
   m_ranked_box = new QCheckBox(tr("Ranked"));
   m_ranked_box->setToolTip(
-      tr("Enabling Ranked Mode will mark down your games as being rankd in the stats files.\nWhen "
+      tr("Enabling Ranked Mode will mark down your games as being ranked in the stats files.\nWhen "
          "sorting through the database, this game will be included as a ranked game.\nThis should "
          "only be toggled for serious games as to keep our database accurate and organized.\nToggling this box will always record & sumit stats, ignoring user configurations."));
 


### PR DESCRIPTION
Force Controller Rumble Enabled is part of default code set. Skip Memory Card Check is part of Netplay Event Code 3.1 which doesn't let memory cards get loaded from the main menu.

I also commented the code set, so that reading & editing this later on will be much easier,