### PR TITLE
Batter Lag Reduction only activates on NetPlay; added to required cod…

### DIFF
--- a/Data/Sys/GameSettings/GYQE01.ini
+++ b/Data/Sys/GameSettings/GYQE01.ini
@@ -3,7 +3,7 @@ $! ReadMe !
 00000000 00000000
 *Thanks for Downloading Project Rio! There's a few things to know:
 *- To obtain all of our mods, use the "Download Codes" button (only works in Project Rio).
-*- Netplay Event Code 3.1 is used to easily set up online games. It contains all of our community mods, which are Unlock Everything, Unlimited Extra Innings, Boot to Main Menu, Manual Fielder Select, Anti Quick Pitch, and Default Competitive Rules.
+*- Netplay Event Code 3.3 is used to easily set up online games. It contains all of our community mods, which are Unlock Everything, Unlimited Extra Innings, Boot to Main Menu, Manual Fielder Select, Anti Quick Pitch, and Default Competitive Rules.
 *- Do not enable this code.
 *
 *That's all -- have fun! Join our Discord to play ranked online games and talk more Mario Superstar Baseball https://discord.com/invite/9ZZtpuEPCd
@@ -60,12 +60,23 @@ c2053afc 00000002
 3c000004 9004005c
 38000000 00000000
 00366177 00000001 #Enable Controller Rumble [LittleCoaks]
+282EBF96 00000000 #Batter Lag Reduction (on/off); Check if 0x802EBF96 is 0 before running rest of code; Project Rio only [LittleCoaks]
+28890976 00000001 #Removes first frame of a batter's swing [LittleCoaks]
+00890977 00000002
+e2000001 00000000
+2289091c 00000000 #Adds 1 to the "frame of contact of pitch" addresss [LittleCoaks]
+c2652360 00000003
+a8031b68 38a0ffff
+2c000fff 41810008
+7c002a14 00000000
+e2000001 00000000
+e2000001 00000000
 *Do not disable this code. This code is necessary for the basic functionality of Project Rio features.
 *
 *As a visual queue that this code is active, the top left of the screen after selecting "Exhibition Game" will display a mushroom.
 *
 *This code automatically enables controller rumble. If you want to disable rumble, turn off rumble in Dolphin's controller settings.
-$!! Netplay Event Code 3.1 !![PeacockSlayer, LittleCoaks]
+$!! Online: Netplay Event Code 3.3 !![PeacockSlayer, LittleCoaks]
 280e877d 00000000 #Boot to Main Menu [LittleCoaks]
 0463f964 38600005
 e2000001 00000000
@@ -244,20 +255,6 @@ A01E0006 00000000
 *
 *Z+Y: SS
 *Z+X: 2nd
-$!! Batter Lag Reduction !![LittleCoaks]
-28890976 00000001 #Removes first frame of a batter's swing
-00890977 00000002
-e2000001 00000000
-2289091c 00000000 #Adds 1 to the "frame of contact of pitch" addresss
-c2652360 00000003
-a8031b68 38a0ffff
-2c000fff 41810008
-7c002a14 00000000
-e2000001 00000000
-*Only enable this when playing NetPlay. Disable when playing locally.
-*
-*Makes everyone's swing come out 1 frame faster, cancelling out 1 frame (4 buffer) of NetPlay delay.
 [Gecko_Enabled]
 $! Required: Project Rio Codes !
-$!! Netplay Event Code 3.1 !!
-$!! Batter Lag Reduction !!
+$!! Online: Netplay Event Code 3.3 !!

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -20,6 +20,8 @@
 
 #include "AudioCommon/AudioCommon.h"
 
+#include "Core/HW/AddressSpace.h"
+
 #include "Common/CPUDetect.h"
 #include "Common/CommonPaths.h"
 #include "Common/CommonTypes.h"
@@ -153,6 +155,15 @@ void FrameUpdateOnCPUThread()
 
 void OnFrameEnd()
 {
+  if (!NetPlay::IsNetPlayRunning())
+  {
+    // sets a specific address to 1 each frame
+    // this address is read by Project Rio's version of Batter Lag Reduction. It only activates when this addr = 1
+    // this system prevents user error of forgetting to turn off lag reduciton when playing local and turning it on for netplay
+    AddressSpace::Accessors* accessors = AddressSpace::GetAccessors(AddressSpace::Type::Effective);
+    accessors->WriteU8(0x802EBF96, 1);
+  }
+
 #ifdef USE_MEMORYWATCHER
   if (s_memory_watcher)
     s_memory_watcher->Step();

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -103,10 +103,11 @@ void NetPlayDialog::CreateMainLayout()
   m_start_button = new QPushButton(tr("Start"));
   m_buffer_size_box = new QSpinBox;
   m_buffer_size_box->setToolTip(
-      tr("Set the buffer based on the ping. The buffer should be ping ÷ 8 (rounded up).\n\nEnabling the \"Batter Lag Reduction\" Gecko Code removes 1 frame (4 buffer) from swings.\n\nFor a simple method, "
-         "use 8 for 64 ping and less, 12 for 100 ping and less, and 16 for 150 ping and "
-         "less.\nGames above 150 ping will be very laggy and are not recommended for competitive "
-         "play."));
+      tr("Set the buffer based on the ping. The buffer should be ping ÷ 8 (rounded up).\n\n"
+      "Project Rio's Batter Lag Reduction mod removes 1 frame (4 buffer) from swings on NetPlay,\n"
+      "and a 120 Hz or greater monitor reduces another 0.5 frames (2 buffer) of general lag.\n\n"
+      "For a simple method, use 8 for 64 ping and less, 12 for 100 ping and less, and 16 for 150 ping and less.\n"
+      "Games above 150 ping will be very laggy and are not recommended for competitive play."));
   m_buffer_label = new QLabel(tr("Buffer:"));
   m_quit_button = new QPushButton(tr("Quit"));
   m_splitter = new QSplitter(Qt::Horizontal);


### PR DESCRIPTION
…e set

Batter Lag Reduction is now part of Project Rio's required code set. It only runs it's code if the game is a NetPlay game.

In Core.cpp, in the OnFrameEnd function, it writes 0x802EBF96 to 1 only if the game is NOT a NetPlay game. The Batter lag Reduction code now has a check for if that addr is 0, and if it is it runs the lag reduction code. If playing locally, that addr will be 1 and batter lag reduction will not run.