### PR TITLE
Add deployment target for Steam Deck using a Flatpak Bundle.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -232,3 +232,31 @@ jobs:
         with:
           name: ${{ matrix.artifact_name }}
           path: "./artifact/"
+  steamOS:
+    runs-on: ubuntu-latest
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:gnome-44
+      options: --privileged
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [ Release ]
+        include:
+          - build_type: Release
+            artifact_name: ProjectRio-steamOS
+            build_config: release
+    name: "steamOS ${{ matrix.build_type }}"
+    steps:
+    - uses: actions/checkout@v2
+    - name: Purge .git for space reasons
+      run: rm -rf /home/runner/work/ProjectRio/ProjectRio/.git
+    - name: Setup Packages
+      run: |
+        sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo && \
+        sudo flatpak install org.kde.Sdk//5.15 org.kde.Platform//5.15 -y && \
+        sudo dnf install libusb1-devel cmake git gcc-c++ libXext-devel libgudev qt6-qtbase-devel systemd-devel openal-soft-devel libevdev-devel libao-devel SOIL-devel libXrandr-devel pulseaudio-libs-devel bluez-libs-devel p7zip SDL2-devel -y
+    - name: Run Flatpak Builder
+      uses: flatpak/flatpak-github-actions@v2
+      with:
+        manifest-path: Tools/flatpak.yml
+        bundle: ${{ matrix.artifact_name }}.flatpak

--- a/Tools/flatpak.yml
+++ b/Tools/flatpak.yml
@@ -1,0 +1,133 @@
+app-id: org.DolphinEmu.project-rio
+branch: master
+runtime: org.kde.Platform
+runtime-version: 6.6
+sdk: org.kde.Sdk
+command: project-rio-wrapper
+rename-desktop-file: project-rio.desktop
+rename-icon: project-rio
+finish-args:
+  - --device=all # need for controllers
+  # the file picker uses portals but the set
+  # game directory feature still needs this
+  - --filesystem=host:ro
+  - --socket=pulseaudio
+  - --env=QT_QPA_PLATFORM=xcb
+  - --socket=x11
+  - --share=network
+  - --share=ipc
+  # along with the bluez module, required for the
+  # emulated bluetooth adapter feature to work.
+  - --allow=bluetooth
+  - --filesystem=xdg-run/app/com.discordapp.Discord:create
+  - --talk-name=org.freedesktop.ScreenSaver
+  # required for Gamescope on Steam Deck
+  - --filesystem=xdg-run/gamescope-0:ro
+modules:
+  # needed for the bluetooth passthrough feature to work
+  - name: libusb
+    config-opts:
+      - --disable-static
+    cleanup:
+      - /include
+      - /lib/*.la
+      - /lib/pkgconfig
+    sources:
+      - type: archive
+        url: https://github.com/libusb/libusb/releases/download/v1.0.26/libusb-1.0.26.tar.bz2
+        sha256: 12ce7a61fc9854d1d2a1ffe095f7b5fac19ddba095c259e6067a46500381b5a5
+        x-checker-data:
+          type: anitya
+          project-id: 1749
+          stable-only: true
+          url-template: https://github.com/libusb/libusb/releases/download/v$version/libusb-$version.tar.bz2
+
+  # needed for the emulate bluetooth adapter feature to work
+  - name: bluez
+    config-opts:
+      - --enable-library
+      - --disable-manpages
+      - --disable-udev
+      - --disable-tools
+      - --disable-cups
+      - --disable-monitor
+      - --disable-client
+      - --disable-systemd
+      - --disable-a2dp
+      - --disable-avrcp
+      - --disable-network
+      - --disable-obex
+      - --disable-bap 
+      - --disable-mcp
+      - --with-dbusconfdir=/app/etc
+      - --with-dbussessionbusdir=/app/usr/lib/system-services
+    sources:
+      - type: archive
+        url: https://www.kernel.org/pub/linux/bluetooth/bluez-5.66.tar.xz
+        sha256: 39fea64b590c9492984a0c27a89fc203e1cdc74866086efb8f4698677ab2b574
+        x-checker-data:
+          type: anitya
+          project-id: 10029
+          stable-only: true
+          url-template: https://www.kernel.org/pub/linux/bluetooth/bluez-$version.tar.xz
+
+  # enables motion controls on non-wii controllers (switch, ps4, etc)
+  # requires a udev rule enabling Motion Sensors access
+  - name: libevdev
+    buildsystem: meson
+    config-opts:
+      - -Dtests=disabled
+      - -Ddocumentation=disabled
+    sources:
+      - type: archive
+        url: https://www.freedesktop.org/software/libevdev/libevdev-1.13.0.tar.xz
+        sha256: 9edf2006cc86a5055279647c38ec923d11a821ee4dc2c3033e8d20e8ee237cd9
+        x-checker-data:
+          type: anitya
+          project-id: 20540
+          stable-only: true
+          url-template: https://www.freedesktop.org/software/libevdev/libevdev-$version.tar.xz
+
+  # needed for screensaver inhibition
+  - name: xdg-screensaver-shim
+    buildsystem: meson
+    sources:
+      - type: archive
+        url: https://github.com/Unrud/xdg-screensaver-shim/archive/0.0.2.tar.gz
+        sha256: 0ed2a69fe6ee6cbffd2fe16f85116db737f17fb1e79bfb812d893cf15c728399
+
+  - name: dolphin-emu
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DENABLE_ALSA=OFF
+      - -DENABLE_SDL=ON
+      - -DENABLE_EVDEV=ON
+      - -DDISTRIBUTOR=Mario Party Netplay
+      - -DCPACK_PACKAGE_CONTACT=Mario Party Netplay
+    cleanup:
+      - /share/man
+    post-install:
+      - install -D -t ${FLATPAK_DEST}/bin/ project-rio-wrapper
+      - desktop-file-edit --set-key=Exec --set-value='/app/bin/project-rio-wrapper'
+        /app/share/applications/project-rio.desktop
+      - desktop-file-edit --set-key=Name --set-value='ProjectRio'
+        /app/share/applications/project-rio.desktop
+    sources:
+      - type: git
+        url: https://github.com/ProjectRio/DolphinProjectRio.git
+
+      # detects whether dolphin is running in a flatpak sandbox
+      # and makes it use xdg directories if it is.
+      # prevents dolphin from attempting to write conf files
+      # in non-writable paths, typically happens when a user
+      # has leftover files from a previous non-flatpak install
+      - type: script
+        commands:
+          - |
+            for i in {0..9}; do
+              test -S $XDG_RUNTIME_DIR/discord-ipc-$i ||
+                ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
+            done
+            project-rio "$@"
+        dest-filename: project-rio-wrapper


### PR DESCRIPTION
This PR integrates Mario Party Netplay's deployment features into Project Rio specifically for Steam Deck support. No other Mario Party Netplay functionality is being used at this time, ensuring a targeted update that does not affect the broader emulator codebase.