### PR TITLE
Change hole naming format

### DIFF
--- a/Source/Core/Core/MGTT_StatTracker.h
+++ b/Source/Core/Core/MGTT_StatTracker.h
@@ -12,6 +12,7 @@
 #include <utility>
 #include <type_traits>
 #include <ctime>
+#include <fmt/format.h>
 #include "Core/HW/Memmap.h"
 
 #include "Common/HttpRequest.h"
@@ -501,7 +502,10 @@ private:
 
     template<typename T>
     std::string getHoleName(T holeNumber, T holeIndex = 0){
-        return fmt::format("H{}_{}", holeNumber, holeIndex);
+        std::string paddedHoleNumber = fmt::format("{:02}", holeNumber);
+        std::string paddedHoleIndex = fmt::format("{:02}", holeIndex);
+
+        return fmt::format("{}_H{}", paddedHoleIndex, paddedHoleNumber);
     }
 
     template<typename T, typename U>


### PR DESCRIPTION
Change the hole name format from H{hole_number}_{hole_index} to {hole_index}_H{hole_number} where the hole_index and hole_number are padded with a 0 if they are a single digit.