### PR TITLE
Add check for enough stars

### DIFF
--- a/Source/Core/Core/MSB_StatTracker.cpp
+++ b/Source/Core/Core/MSB_StatTracker.cpp
@@ -778,7 +778,7 @@ void StatTracker::logPitch(const Core::CPUThreadGuard& guard, Event& in_event){
     u8 star_swing = PowerPC::MMU::HostRead_U8(guard, aAB_StarSwing);
     u8 adjusted_swing = 0; //0=miss, 1=slap, 2=charge, 3=star, 4=bunt
     //Adjust swing to definition
-    if (star_swing != 0){
+    if (star_swing != 0 && hasEnoughStarsForStarSwing(guard, in_event)){
         adjusted_swing = 3;
     }
     else {
@@ -2174,4 +2174,27 @@ void StatTracker::updateOngoingGame(Event& in_curr_event){
                 {"Content-Type", "application/json"},
             }
         );
+}
+
+bool StatTracker::hasEnoughStarsForStarSwing(const Core::CPUThreadGuard& guard, Event& in_event)
+{
+    u8 batter_stars = (in_event.half_inning == 0) ? in_event.away_stars : in_event.home_stars;
+
+    u8 batter_roster_loc = in_event.batter_roster_loc;
+    u8 batter_char_id = m_game_info.character_summaries[in_event.half_inning][batter_roster_loc].char_id;
+
+    u8 captain_roster_loc = (in_event.half_inning == 0)
+        ? ((m_game_info.away_port == m_game_info.team0_port) ? m_game_info.team0_captain_roster_loc : m_game_info.team1_captain_roster_loc)
+        : ((m_game_info.home_port == m_game_info.team0_port) ? m_game_info.team0_captain_roster_loc : m_game_info.team1_captain_roster_loc);
+
+    u8 star_cost;
+    if (batter_roster_loc == captain_roster_loc) {
+        star_cost = 1; // actual captain
+    } else if (cCaptainTypeCharIds.count(batter_char_id)) {
+        star_cost = 2; // captain-type but not the captain this game
+    } else {
+        star_cost = 1; // non-captain character
+    }
+
+    return batter_stars >= star_cost;
 }

--- a/Source/Core/Core/MSB_StatTracker.cpp
+++ b/Source/Core/Core/MSB_StatTracker.cpp
@@ -177,15 +177,14 @@ void StatTracker::lookForTriggerEvents(const Core::CPUThreadGuard& guard)
                     m_game_info.events[m_game_info.event_num] = Event();
                     m_game_info.getCurrentEvent().event_num = m_game_info.event_num;
 
-                    logEventState(guard, m_game_info.getCurrentEvent());
-                    logGameInfo(guard);
-
                     //Get users and captains
-                    //POST OngoingGame
                     if (m_game_info.init_game == true) {
                         m_game_info.init_game = false;
                         initPlayerInfo(guard);
                     }
+
+                    logEventState(guard, m_game_info.getCurrentEvent());
+                    logGameInfo(guard);
 
                     m_game_info.getCurrentEvent().runner_batter = logRunnerInfo(guard, 0);
                     m_game_info.getCurrentEvent().runner_1 = logRunnerInfo(guard, 1);

--- a/Source/Core/Core/MSB_StatTracker.h
+++ b/Source/Core/Core/MSB_StatTracker.h
@@ -133,6 +133,21 @@ static const std::map<u8, std::string> cCharIdToCharName = {
     {0x35, "Bro(B)"}
 };
 
+static const std::set<u8> cCaptainTypeCharIds = {
+    0x0,  // Mario
+    0x1,  // Luigi
+    0x2,  // DK
+    0x3,  // Diddy
+    0x4,  // Peach
+    0x5,  // Daisy
+    0x6,  // Yoshi
+    0x9,  // Bowser
+    0xa,  // Wario
+    0xb,  // Waluigi
+    0x11, // Birdo
+    0x13, // Bowser Jr
+};
+
 static const std::map<u8, std::string> cStadiumIdToStadiumName = {
     {0x0, "Mario Stadium"},
     {0x1, "Bowser Castle"},
@@ -532,7 +547,8 @@ static const u32 aAB_ContactRandInt3 = 0x802ec014;
 
 static const u32 aAB_ContactAbsolute = 0x80890950;
 static const u32 aAB_ContactQuality  = 0x80890954;
-static const u32 aAB_TypeOfSwing    = 0x8089099B; //1=Slap, 2=Charge, 3=Bunt. Set on contact
+// 0=slap/linedrive star, 1=charge/grounder star/pop star, 2=captain star/moonshot, 3=bunt
+static const u32 aAB_TypeOfSwing    = 0x8089099B; 
 static const u32 aAB_ChargeUp       = 0x80890968;
 static const u32 aAB_ChargeDown     = 0x8089096C;
 static const u32 aAB_BatterHand     = 0x8089098B; //Right=0, Left=1
@@ -1148,6 +1164,7 @@ public:
     //RunnerInfo
     std::optional<Runner> logRunnerInfo(const Core::CPUThreadGuard& guard, u8 base);
     bool anyRunnerStealing(const Core::CPUThreadGuard& guard, Event& in_event);
+    bool hasEnoughStarsForStarSwing(const Core::CPUThreadGuard& guard, Event& in_event);
     void logRunnerEvents(const Core::CPUThreadGuard& guard, Runner* in_runner);
 
     //TODO Redo these tuple functions


### PR DESCRIPTION
The star swing indicator variable is unreliable, so need to add checks if the batter has enough stars to trigger a star swing.