### PR TITLE
Overhaul macOS build and CI: dual-arch runners, bundle fix, and ad-hoc codesign

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -214,7 +214,6 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           git config core.fileMode false
-          chmod +x ./build-mac.sh
           ./build-mac.sh release
       - name: "Package"
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,7 +163,7 @@ jobs:
             artifact_name: ProjectRio-macOS-x86_64
     name: "macOS ${{ matrix.arch }}"
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 120
+    timeout-minutes: 90
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,25 +154,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build_type: [ Release ]
-        arch: [ arm64, x86_64 ]
         include:
           - arch: arm64
+            runner: macos-26
             artifact_name: ProjectRio-macOS-arm64
           - arch: x86_64
+            runner: macos-26-intel
             artifact_name: ProjectRio-macOS-x86_64
-          - build_type: Release
-            build_config: release
-    name: "macOS ${{ matrix.build_type }} ${{ matrix.arch }}"
-    runs-on: macos-15
-    timeout-minutes: 90
+    name: "macOS ${{ matrix.arch }}"
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 120
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: 'Fetch Git Tags'
-        if: success()
+      - name: "Fetch Git Tags"
         run: |
           git fetch --prune --unshallow
           echo "GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_ENV
@@ -190,21 +187,6 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.arch }}-brew-${{ hashFiles('.github/workflows/main.yml') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.arch }}-brew-
-      - name: "Cache x86_64 Homebrew prefix"
-        if: matrix.arch == 'x86_64'
-        uses: actions/cache@v3
-        with:
-          path: |
-            /usr/local/Homebrew
-            /usr/local/Cellar
-            /usr/local/opt
-            /usr/local/bin
-            /usr/local/lib
-            /usr/local/include
-            /usr/local/share
-          key: ${{ runner.os }}-brew-x86_64-prefix-${{ hashFiles('.github/workflows/main.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-brew-x86_64-prefix-
       - name: "Cache ccache"
         uses: actions/cache@v3
         with:
@@ -212,37 +194,11 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.arch }}-ccache-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.arch }}-ccache-
-      - name: "Install prerequisites (arm64)"
-        if: success() && matrix.arch == 'arm64'
+      - name: "Install prerequisites"
         shell: bash
         run: |
-          rm '/usr/local/bin/2to3' || true
           export HOMEBREW_NO_AUTO_UPDATE=1
           brew install \
-          ccache \
-          ffmpeg \
-          libpng \
-          pkgconfig \
-          libao \
-          sound-touch \
-          hidapi \
-          icu4c \
-          qt@6
-          brew unlink fmt || true
-      - name: "Install prerequisites (x86_64 via Rosetta)"
-        if: success() && matrix.arch == 'x86_64'
-        shell: bash
-        run: |
-          export HOMEBREW_NO_AUTO_UPDATE=1
-          echo "HOMEBREW_NO_AUTO_UPDATE=1" >> $GITHUB_ENV
-          if [ ! -x /usr/local/bin/brew ]; then
-            echo "Installing x86_64 Homebrew under Rosetta..."
-            arch -x86_64 /bin/bash -c \
-              "NONINTERACTIVE=1 /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\""
-          fi
-          echo "/usr/local/bin" >> $GITHUB_PATH
-          arch -x86_64 /usr/local/bin/brew install \
-            cmake \
             ccache \
             ffmpeg \
             libpng \
@@ -252,25 +208,15 @@ jobs:
             hidapi \
             icu4c \
             qt@6
-          arch -x86_64 /usr/local/bin/brew unlink fmt || true
-      - name: "Build ${{ matrix.build_type }} Project Rio (arm64)"
-        if: success() && matrix.arch == 'arm64'
+          brew unlink fmt || true
+      - name: "Build ${{ matrix.arch }}"
         shell: bash
         working-directory: ${{ github.workspace }}
-        run: |
-          git config core.fileMode false ; chmod +x ./build-mac.sh && ./build-mac.sh ${{ matrix.build_config }}
-      - name: "Build ${{ matrix.build_type }} Project Rio (x86_64 via Rosetta)"
-        if: success() && matrix.arch == 'x86_64'
-        shell: bash
-        working-directory: ${{ github.workspace }}
-        env:
-          BUILD_ARCH: x86_64
         run: |
           git config core.fileMode false
           chmod +x ./build-mac.sh
-          arch -x86_64 /bin/bash ./build-mac.sh ${{ matrix.build_config }}
-      - name: Package ${{ matrix.build_type }}
-        if: success()
+          ./build-mac.sh release
+      - name: "Package"
         shell: bash
         working-directory: ${{ github.workspace }}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -164,7 +164,7 @@ jobs:
           - build_type: Release
             build_config: release
     name: "macOS ${{ matrix.build_type }} ${{ matrix.arch }}"
-    runs-on: macos-14
+    runs-on: macos-15
     timeout-minutes: 90
     steps:
       - name: "Checkout"
@@ -217,8 +217,7 @@ jobs:
         shell: bash
         run: |
           rm '/usr/local/bin/2to3' || true
-          echo "HOMEBREW_NO_AUTO_UPDATE=1" >> $GITHUB_ENV
-          brew upgrade cmake
+          export HOMEBREW_NO_AUTO_UPDATE=1
           brew install \
           ccache \
           ffmpeg \
@@ -242,7 +241,6 @@ jobs:
               "NONINTERACTIVE=1 /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\""
           fi
           echo "/usr/local/bin" >> $GITHUB_PATH
-          arch -x86_64 /usr/local/bin/brew update-reset || true
           arch -x86_64 /usr/local/bin/brew install \
             cmake \
             ccache \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -223,7 +223,7 @@ jobs:
           FILE_NAME=${{ env.CURR_DATE }}-${{ env.GIT_HASH }}-${{ env.GIT_TAG }}-${{ matrix.artifact_name }}.zip
           mkdir artifact
           cd ./build/Binaries/
-          zip -r "${FILE_NAME}" "ProjectRio.app"
+          zip -ry "${FILE_NAME}" "ProjectRio.app"
           mv "${FILE_NAME}" ../../artifact/
       - name: "Publish"
         if: success()

--- a/build-mac.sh
+++ b/build-mac.sh
@@ -25,46 +25,6 @@ if command -v ccache &> /dev/null; then
     CMAKE_FLAGS+=' -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache'
 fi
 
-# Normalize Homebrew dylib hard links to proper symlinks before cmake runs.
-# CI Homebrew sometimes installs versioned dylib aliases (e.g. libavcodec.62.dylib
-# and libavcodec.62.28.101.dylib) as hard links rather than symlinks. CMake's
-# fixup_bundle copies both. Converting aliases to symlinks means fixup_bundle
-# sees only one canonical copy per library.
-echo "Normalizing Homebrew dylib symlinks in ${BREW_PREFIX}/lib..."
-python3 - "${BREW_PREFIX}/lib" <<'PYEOF'
-import os, sys
-
-lib_dir = sys.argv[1]
-if not os.path.isdir(lib_dir):
-    sys.exit(0)
-
-inodes = {}
-for name in os.listdir(lib_dir):
-    if not name.endswith('.dylib'):
-        continue
-    path = os.path.join(lib_dir, name)
-    if os.path.islink(path):
-        continue
-    try:
-        inodes.setdefault(os.stat(path).st_ino, []).append(path)
-    except OSError:
-        pass
-
-normalized = 0
-for paths in inodes.values():
-    if len(paths) < 2:
-        continue
-    paths.sort(key=lambda p: len(os.path.basename(p)), reverse=True)
-    canonical = paths[0]
-    for alias in paths[1:]:
-        os.remove(alias)
-        os.symlink(os.path.basename(canonical), alias)
-        print(f"  {os.path.basename(alias)} -> {os.path.basename(canonical)}")
-        normalized += 1
-
-print(f"Normalized {normalized} dylib alias(es).")
-PYEOF
-
 mkdir -p build
 pushd build
 cmake ${CMAKE_FLAGS} ..
@@ -73,3 +33,64 @@ popd
 
 echo "Copying Sys files into the bundle"
 cp -Rfn "${DATA_SYS_PATH}" "${BINARY_PATH}"
+
+# fixup_bundle copies versioned dylib aliases (e.g. libavcodec.62.dylib and
+# libavcodec.62.28.101.dylib) as separate full-size files, and copies Qt framework
+# binaries to multiple locations (Versions/A/, Versions/Current/, and the top-level
+# framework directory) instead of keeping symlinks. Deduplicate by content after the
+# bundle is fully assembled: for each set of identical files, keep the most canonical
+# copy and delete the rest. Nothing in the bundle references the deleted paths because
+# fixup_bundle already rewrote all install names to point at the canonical copies.
+echo "Deduplicating bundle frameworks..."
+python3 - "./build/Binaries/ProjectRio.app/Contents/Frameworks" <<'PYEOF'
+import os, sys, hashlib
+
+def sha256(path):
+    h = hashlib.sha256()
+    with open(path, 'rb') as f:
+        while True:
+            chunk = f.read(65536)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+frameworks = sys.argv[1]
+if not os.path.isdir(frameworks):
+    sys.exit(0)
+
+file_hashes = {}
+for dirpath, dirnames, filenames in os.walk(frameworks):
+    for fname in filenames:
+        fpath = os.path.join(dirpath, fname)
+        if os.path.islink(fpath):
+            continue
+        try:
+            file_hashes.setdefault(sha256(fpath), []).append(fpath)
+        except OSError:
+            pass
+
+def priority(p):
+    rel = os.path.relpath(p, frameworks)
+    name = os.path.basename(p)
+    if 'Versions/A' in rel:
+        return (2, len(name))
+    if 'Versions/Current' in rel:
+        return (0, len(name))
+    return (1, len(name))
+
+deleted = 0
+freed = 0
+for paths in file_hashes.values():
+    if len(paths) < 2:
+        continue
+    paths.sort(key=priority, reverse=True)
+    for dup in paths[1:]:
+        size = os.path.getsize(dup)
+        os.remove(dup)
+        freed += size
+        deleted += 1
+        print(f"  Removed: {os.path.relpath(dup, frameworks)}")
+
+print(f"Removed {deleted} duplicate file(s), freed {freed / 1024 / 1024:.1f} MB")
+PYEOF

--- a/build-mac.sh
+++ b/build-mac.sh
@@ -10,15 +10,10 @@ export LIBRARY_PATH=$LIBRARY_PATH:${BREW_PREFIX}/lib:/usr/local/lib:/usr/lib/
 QT_BREW_PATH=$(brew --prefix qt@6)
 CMAKE_FLAGS="-DQt6_DIR=${QT_BREW_PATH}/lib/cmake/Qt6 -DENABLE_NOGUI=false"
 
-# Always disable CMake's POST_BUILD codesign step. Any signature produced there
-# would be invalidated by the framework layout pass below, so we sign once at
-# the end of this script instead.
+# Disable CMake's POST_BUILD codesign step. Any signature it produced would be
+# invalidated by the framework layout pass below, so we ad-hoc sign once at the
+# end of this script instead.
 CMAKE_FLAGS+=' -DMACOS_CODE_SIGNING="OFF"'
-if [[ -z "${CERTIFICATE_MACOS_APPLICATION}" ]]; then
-    echo "Building without release code signing (will ad-hoc sign at end)"
-else
-    echo "Building with release code signing (signed at end of script)"
-fi
 
 CMAKE_FLAGS+=' -DCMAKE_POLICY_VERSION_MINIMUM=3.5'
 
@@ -87,7 +82,8 @@ frameworks = sys.argv[1]
 if not os.path.isdir(frameworks):
     sys.exit(0)
 
-freed = 0
+layout_freed = 0
+dedup_freed = 0
 
 # Pass 1: rebuild proper framework layout (Versions/Current symlink + top-level symlinks).
 for entry in sorted(os.listdir(frameworks)):
@@ -114,7 +110,7 @@ for entry in sorted(os.listdir(frameworks)):
     # Replace Versions/Current with a symlink to the real version directory.
     current = os.path.join(versions_dir, 'Current')
     if os.path.lexists(current):
-        freed += tree_size(current)
+        layout_freed += tree_size(current)
         remove(current)
     os.symlink(real_version, current)
 
@@ -125,7 +121,7 @@ for entry in sorted(os.listdir(frameworks)):
         if os.path.islink(top):
             continue
         if os.path.lexists(top):
-            freed += tree_size(top)
+            layout_freed += tree_size(top)
             remove(top)
         os.symlink(os.path.join('Versions', 'Current', child), top)
 
@@ -160,58 +156,42 @@ for paths in file_hashes.values():
     keep = paths[0]
     for dup in paths[1:]:
         rel_target = os.path.relpath(keep, os.path.dirname(dup))
-        freed += os.path.getsize(dup)
+        dedup_freed += os.path.getsize(dup)
         os.unlink(dup)
         os.symlink(rel_target, dup)
         linked += 1
         print(f"  Linked: {os.path.relpath(dup, frameworks)} -> {rel_target}")
 
-print(f"Replaced duplicates with {linked} symlink(s), freed {freed / 1024 / 1024:.1f} MB")
+total_freed = layout_freed + dedup_freed
+print(f"Framework layout fix freed {layout_freed / 1024 / 1024:.1f} MB; "
+      f"deduped {linked} file(s) freed {dedup_freed / 1024 / 1024:.1f} MB "
+      f"(total {total_freed / 1024 / 1024:.1f} MB)")
 PYEOF
 
-# Sign the bundle AFTER the layout fix so the signature covers the final state.
-# fixup_bundle rewrites install names on Homebrew dylibs, which invalidates their
-# original signatures; the layout pass above further modifies the bundle. Without
-# a fresh signature macOS marks the app as "damaged".
+# Ad-hoc sign the bundle AFTER the layout fix so the signature covers the final
+# state. fixup_bundle rewrites install names on Homebrew dylibs (invalidating
+# their original signatures) and the layout pass above further modifies the
+# bundle, so without a fresh signature macOS marks the app as "damaged".
 #
 # Signing is done inside-out (Apple's recommended pattern, replacing the now-
 # deprecated --deep flag): every nested .dylib and .framework is signed first
 # (deepest paths first, via `find -depth`), then the outer .app is signed last
 # so its signature seals over the already-signed nested code.
+#
+# This script only ad-hoc signs; release signing + notarization is not wired up
+# yet. When it is, add the cert import, identity, hardened-runtime opts, and
+# entitlements as one cohesive change rather than half-scaffolded here.
 APP="./build/Binaries/ProjectRio.app"
-if [[ -z "${CERTIFICATE_MACOS_APPLICATION}" ]]; then
-    echo "Ad-hoc signing bundle (inside-out)..."
-    SIGN_IDENTITY="-"
-    RUNTIME_OPTS=()
-    ENTITLEMENT_OPTS=()
-else
-    echo "Release signing bundle (inside-out)..."
-    SIGN_IDENTITY="${MACOS_CODE_SIGNING_IDENTITY}"
-    RUNTIME_OPTS=(--options=runtime)
-    ENTITLEMENT_OPTS=(--entitlements "Source/Core/DolphinQt/DolphinEmu.entitlements")
-fi
+echo "Ad-hoc signing bundle (inside-out)..."
 
-# Sign nested Mach-O code first (dylibs and frameworks), deepest first.
 while IFS= read -r -d '' item; do
-    codesign --force "${RUNTIME_OPTS[@]}" --sign "${SIGN_IDENTITY}" "${item}"
+    codesign --force --sign - "${item}"
 done < <(find "${APP}/Contents" -depth \( -name "*.dylib" -o -name "*.framework" \) -print0)
 
-# Sign the outer app last, sealing over the nested signatures. Entitlements are
-# applied only to the main bundle (hardened runtime opts propagate via the
-# nested signatures above).
-codesign --force "${RUNTIME_OPTS[@]}" "${ENTITLEMENT_OPTS[@]}" --sign "${SIGN_IDENTITY}" "${APP}"
+codesign --force --sign - "${APP}"
 
-# Verify the result so a broken bundle fails the build instead of shipping.
-# --deep is deprecated for signing but is still the recommended form for
-# verification: it walks every nested signature instead of relying solely on
-# the outer seal's CodeResources hashes.
+# Verify so a broken bundle fails the build instead of shipping. --deep is
+# deprecated for signing but is still the recommended form for verification:
+# it walks every nested signature instead of relying solely on the outer
+# seal's CodeResources hashes.
 codesign --verify --deep --strict --verbose=2 "${APP}"
-
-# On release builds, also run the full Gatekeeper assessment — the same check
-# the user's Mac performs at first launch. This will fail until the bundle is
-# notarized, so it is informational only (|| true) and skipped on ad-hoc builds
-# where it would always fail.
-if [[ -n "${CERTIFICATE_MACOS_APPLICATION}" ]]; then
-    echo "Running Gatekeeper assessment (informational, pre-notarization):"
-    spctl --assess --type execute --verbose=2 "${APP}" || true
-fi

--- a/build-mac.sh
+++ b/build-mac.sh
@@ -34,6 +34,15 @@ popd
 echo "Copying Sys files into the bundle"
 cp -Rfn "${DATA_SYS_PATH}" "${BINARY_PATH}"
 
+# When no real certificate is present, ad-hoc sign the bundle so macOS does not
+# reject it as "damaged" due to Homebrew dylibs that fixup_bundle modified after
+# they were originally signed. Ad-hoc signing replaces the broken signatures and
+# allows users to open the app via right-click -> Open or Settings > Privacy.
+if [[ -z "${CERTIFICATE_MACOS_APPLICATION}" ]]; then
+    echo "Ad-hoc signing bundle..."
+    codesign --force --deep --sign - "./build/Binaries/ProjectRio.app"
+fi
+
 # fixup_bundle copies versioned dylib aliases (e.g. libavcodec.62.dylib and
 # libavcodec.62.28.101.dylib) as separate full-size files, and copies Qt framework
 # binaries to multiple locations (Versions/A/, Versions/Current/, and the top-level

--- a/build-mac.sh
+++ b/build-mac.sh
@@ -1,44 +1,75 @@
 #!/bin/bash -e
 # build-mac.sh
 
-QT_BREW_PATH=$(brew --prefix qt@6)
-CMAKE_FLAGS="-DQt6_DIR=${QT_BREW_PATH}/lib/cmake/Qt6 -DENABLE_NOGUI=false"
-
 DATA_SYS_PATH="./Data/Sys/"
 BINARY_PATH="./build/Binaries/ProjectRio.app/Contents/Resources/"
 
 BREW_PREFIX=$(brew --prefix)
 export LIBRARY_PATH=$LIBRARY_PATH:${BREW_PREFIX}/lib:/usr/local/lib:/usr/lib/
 
-if [[ -z "${CERTIFICATE_MACOS_APPLICATION}" ]]
-    then
-        echo "Building without code signing"
-        CMAKE_FLAGS+=' -DMACOS_CODE_SIGNING="OFF"'
+QT_BREW_PATH=$(brew --prefix qt@6)
+CMAKE_FLAGS="-DQt6_DIR=${QT_BREW_PATH}/lib/cmake/Qt6 -DENABLE_NOGUI=false"
+
+if [[ -z "${CERTIFICATE_MACOS_APPLICATION}" ]]; then
+    echo "Building without code signing"
+    CMAKE_FLAGS+=' -DMACOS_CODE_SIGNING="OFF"'
 else
-        echo "Building with code signing"
-        CMAKE_FLAGS+=' -DMACOS_CODE_SIGNING="ON"'
+    echo "Building with code signing"
+    CMAKE_FLAGS+=' -DMACOS_CODE_SIGNING="ON"'
 fi
 
 CMAKE_FLAGS+=' -DCMAKE_POLICY_VERSION_MINIMUM=3.5'
 
-# When BUILD_ARCH is set (CI cross-builds x86_64 on Apple Silicon via Rosetta),
-# pin the slice we produce. Otherwise CMake targets the host arch.
-if [[ -n "${BUILD_ARCH}" ]]; then
-    CMAKE_FLAGS+=" -DCMAKE_OSX_ARCHITECTURES=${BUILD_ARCH}"
-fi
-
-# Use ccache if available (speeds up incremental CI builds significantly)
+# Use ccache if available
 if command -v ccache &> /dev/null; then
     CMAKE_FLAGS+=' -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache'
 fi
 
-# Move into the build directory, run CMake, and compile the project
+# Normalize Homebrew dylib hard links to proper symlinks before cmake runs.
+# CI Homebrew sometimes installs versioned dylib aliases (e.g. libavcodec.62.dylib
+# and libavcodec.62.28.101.dylib) as hard links rather than symlinks. CMake's
+# fixup_bundle copies both. Converting aliases to symlinks means fixup_bundle
+# sees only one canonical copy per library.
+echo "Normalizing Homebrew dylib symlinks in ${BREW_PREFIX}/lib..."
+python3 - "${BREW_PREFIX}/lib" <<'PYEOF'
+import os, sys
+
+lib_dir = sys.argv[1]
+if not os.path.isdir(lib_dir):
+    sys.exit(0)
+
+inodes = {}
+for name in os.listdir(lib_dir):
+    if not name.endswith('.dylib'):
+        continue
+    path = os.path.join(lib_dir, name)
+    if os.path.islink(path):
+        continue
+    try:
+        inodes.setdefault(os.stat(path).st_ino, []).append(path)
+    except OSError:
+        pass
+
+normalized = 0
+for paths in inodes.values():
+    if len(paths) < 2:
+        continue
+    paths.sort(key=lambda p: len(os.path.basename(p)), reverse=True)
+    canonical = paths[0]
+    for alias in paths[1:]:
+        os.remove(alias)
+        os.symlink(os.path.basename(canonical), alias)
+        print(f"  {os.path.basename(alias)} -> {os.path.basename(canonical)}")
+        normalized += 1
+
+print(f"Normalized {normalized} dylib alias(es).")
+PYEOF
+
 mkdir -p build
 pushd build
 cmake ${CMAKE_FLAGS} ..
 cmake --build . --target dolphin-emu -- -j$(sysctl -n hw.logicalcpu)
 popd
 
-# Copy the Sys folder in
 echo "Copying Sys files into the bundle"
-cp -Rfn "${DATA_SYS_PATH}" "${BINARY_PATH}" 
+cp -Rfn "${DATA_SYS_PATH}" "${BINARY_PATH}"

--- a/build-mac.sh
+++ b/build-mac.sh
@@ -34,72 +34,146 @@ popd
 echo "Copying Sys files into the bundle"
 cp -Rfn "${DATA_SYS_PATH}" "${BINARY_PATH}"
 
-# When no real certificate is present, ad-hoc sign the bundle so macOS does not
-# reject it as "damaged" due to Homebrew dylibs that fixup_bundle modified after
-# they were originally signed. Ad-hoc signing replaces the broken signatures and
-# allows users to open the app via right-click -> Open or Settings > Privacy.
-if [[ -z "${CERTIFICATE_MACOS_APPLICATION}" ]]; then
-    echo "Ad-hoc signing bundle..."
-    codesign --force --deep --sign - "./build/Binaries/ProjectRio.app"
-fi
-
-# fixup_bundle copies versioned dylib aliases (e.g. libavcodec.62.dylib and
-# libavcodec.62.28.101.dylib) as separate full-size files, and copies Qt framework
-# binaries to multiple locations (Versions/A/, Versions/Current/, and the top-level
-# framework directory) instead of keeping symlinks. Deduplicate by content after the
-# bundle is fully assembled: for each set of identical files, keep the most canonical
-# copy and delete the rest. Nothing in the bundle references the deleted paths because
-# fixup_bundle already rewrote all install names to point at the canonical copies.
-echo "Deduplicating bundle frameworks..."
+# fixup_bundle expands every framework/dylib symlink into a full file copy:
+#   - Versioned dylib aliases (libfoo.62.dylib + libfoo.62.28.101.dylib) become
+#     two identical full-size files instead of one file + one symlink.
+#   - Qt frameworks end up with the binary duplicated at Versions/A/Foo,
+#     Versions/Current/Foo, and Foo.framework/Foo, and Versions/Current is a
+#     real directory instead of a symlink to A. That layout is structurally
+#     invalid for a macOS framework and Gatekeeper rejects it as "damaged",
+#     regardless of code signing.
+#
+# Restore the canonical layout: for each framework, keep Versions/<X> as the
+# only real copy and replace Versions/Current and the top-level entries with
+# the symlinks Apple's framework spec requires. For loose dylib aliases,
+# keep the most-specific version as the real file and symlink the shorter
+# aliases to it (mirroring Homebrew's own layout).
+echo "Restoring framework symlinks and deduplicating..."
 python3 - "./build/Binaries/ProjectRio.app/Contents/Frameworks" <<'PYEOF'
-import os, sys, hashlib
+import os, sys, shutil, hashlib
 
 def sha256(path):
     h = hashlib.sha256()
     with open(path, 'rb') as f:
-        while True:
-            chunk = f.read(65536)
-            if not chunk:
-                break
+        for chunk in iter(lambda: f.read(65536), b''):
             h.update(chunk)
     return h.hexdigest()
+
+def tree_size(path):
+    if os.path.islink(path) or not os.path.exists(path):
+        return 0
+    if os.path.isfile(path):
+        return os.path.getsize(path)
+    total = 0
+    for dp, _, fns in os.walk(path):
+        for f in fns:
+            fp = os.path.join(dp, f)
+            if not os.path.islink(fp):
+                try:
+                    total += os.path.getsize(fp)
+                except OSError:
+                    pass
+    return total
+
+def remove(path):
+    if os.path.islink(path) or os.path.isfile(path):
+        os.unlink(path)
+    elif os.path.isdir(path):
+        shutil.rmtree(path)
 
 frameworks = sys.argv[1]
 if not os.path.isdir(frameworks):
     sys.exit(0)
 
+freed = 0
+
+# Pass 1: rebuild proper framework layout (Versions/Current symlink + top-level symlinks).
+for entry in sorted(os.listdir(frameworks)):
+    if not entry.endswith('.framework'):
+        continue
+    fw = os.path.join(frameworks, entry)
+    versions_dir = os.path.join(fw, 'Versions')
+    if not os.path.isdir(versions_dir) or os.path.islink(versions_dir):
+        continue
+
+    # Find the actual version directory (anything that isn't "Current" and is a real dir).
+    real_version = None
+    for v in sorted(os.listdir(versions_dir)):
+        if v == 'Current':
+            continue
+        vp = os.path.join(versions_dir, v)
+        if os.path.isdir(vp) and not os.path.islink(vp):
+            real_version = v
+            break
+    if real_version is None:
+        continue
+    real_version_path = os.path.join(versions_dir, real_version)
+
+    # Replace Versions/Current with a symlink to the real version directory.
+    current = os.path.join(versions_dir, 'Current')
+    if os.path.lexists(current):
+        freed += tree_size(current)
+        remove(current)
+    os.symlink(real_version, current)
+
+    # For each top-level entry inside Versions/<X>, ensure a matching symlink at
+    # the framework root pointing at Versions/Current/<entry>.
+    for child in os.listdir(real_version_path):
+        top = os.path.join(fw, child)
+        if os.path.islink(top):
+            continue
+        if os.path.lexists(top):
+            freed += tree_size(top)
+            remove(top)
+        os.symlink(os.path.join('Versions', 'Current', child), top)
+
+# Pass 2: dedup any remaining content-identical real files (mostly versioned
+# dylib aliases at the top of Frameworks/). os.walk does not follow symlinks
+# by default, so framework internals are visited exactly once via Versions/<X>.
 file_hashes = {}
-for dirpath, dirnames, filenames in os.walk(frameworks):
-    for fname in filenames:
-        fpath = os.path.join(dirpath, fname)
-        if os.path.islink(fpath):
+for dp, _, fns in os.walk(frameworks):
+    for fn in fns:
+        fp = os.path.join(dp, fn)
+        if os.path.islink(fp):
             continue
         try:
-            file_hashes.setdefault(sha256(fpath), []).append(fpath)
+            file_hashes.setdefault(sha256(fp), []).append(fp)
         except OSError:
             pass
 
-def priority(p):
+def canonical_score(p):
+    # Prefer files living inside a Versions/<X>/ directory (the proper home for
+    # a framework binary). Otherwise prefer the longest filename, which for
+    # dylib aliases is the most-specific version (libfoo.62.28.101.dylib over
+    # libfoo.62.dylib).
     rel = os.path.relpath(p, frameworks)
-    name = os.path.basename(p)
-    if 'Versions/A' in rel:
-        return (2, len(name))
-    if 'Versions/Current' in rel:
-        return (0, len(name))
-    return (1, len(name))
+    in_version = '/Versions/' in rel and '/Versions/Current/' not in rel
+    return (in_version, len(os.path.basename(p)))
 
-deleted = 0
-freed = 0
+linked = 0
 for paths in file_hashes.values():
     if len(paths) < 2:
         continue
-    paths.sort(key=priority, reverse=True)
+    paths.sort(key=canonical_score, reverse=True)
+    keep = paths[0]
     for dup in paths[1:]:
-        size = os.path.getsize(dup)
-        os.remove(dup)
-        freed += size
-        deleted += 1
-        print(f"  Removed: {os.path.relpath(dup, frameworks)}")
+        rel_target = os.path.relpath(keep, os.path.dirname(dup))
+        freed += os.path.getsize(dup)
+        os.unlink(dup)
+        os.symlink(rel_target, dup)
+        linked += 1
+        print(f"  Linked: {os.path.relpath(dup, frameworks)} -> {rel_target}")
 
-print(f"Removed {deleted} duplicate file(s), freed {freed / 1024 / 1024:.1f} MB")
+print(f"Replaced duplicates with {linked} symlink(s), freed {freed / 1024 / 1024:.1f} MB")
 PYEOF
+
+# Ad-hoc sign AFTER the layout fix so the signature covers the final bundle
+# state. fixup_bundle modifies Homebrew dylibs (rewriting install names), which
+# invalidates their original signatures; without a fresh signature macOS marks
+# the app as "damaged". A real certificate is used when CERTIFICATE_MACOS_APPLICATION
+# is set; otherwise an ad-hoc signature is enough to satisfy Gatekeeper after a
+# right-click -> Open or via Settings > Privacy.
+if [[ -z "${CERTIFICATE_MACOS_APPLICATION}" ]]; then
+    echo "Ad-hoc signing bundle..."
+    codesign --force --deep --sign - "./build/Binaries/ProjectRio.app"
+fi

--- a/build-mac.sh
+++ b/build-mac.sh
@@ -176,7 +176,10 @@ PYEOF
 # Signing is done inside-out (Apple's recommended pattern, replacing the now-
 # deprecated --deep flag): every nested .dylib and .framework is signed first
 # (deepest paths first, via `find -depth`), then the outer .app is signed last
-# so its signature seals over the already-signed nested code.
+# so its signature seals over the already-signed nested code. All nested items
+# are passed to a single codesign invocation via xargs so we pay process-startup
+# overhead once instead of once per file — the Intel CI runner is slow enough
+# that the per-call overhead dominated total build time when this was a loop.
 #
 # This script only ad-hoc signs; release signing + notarization is not wired up
 # yet. When it is, add the cert import, identity, hardened-runtime opts, and
@@ -184,14 +187,15 @@ PYEOF
 APP="./build/Binaries/ProjectRio.app"
 echo "Ad-hoc signing bundle (inside-out)..."
 
-while IFS= read -r -d '' item; do
-    codesign --force --sign - "${item}"
-done < <(find "${APP}/Contents" -depth \( -name "*.dylib" -o -name "*.framework" \) -print0)
+# Pipe all nested items into one codesign invocation so process-startup cost is paid once.
+find "${APP}/Contents" -depth \( -name "*.dylib" -o -name "*.framework" \) -print0 \
+    | xargs -0 codesign --force --sign -
 
 codesign --force --sign - "${APP}"
 
-# Verify so a broken bundle fails the build instead of shipping. --deep is
-# deprecated for signing but is still the recommended form for verification:
-# it walks every nested signature instead of relying solely on the outer
-# seal's CodeResources hashes.
-codesign --verify --deep --strict --verbose=2 "${APP}"
+# Verify so a broken bundle fails the build instead of shipping. The outer
+# seal's CodeResources hashes already cover every nested file, so verifying
+# without --deep catches the failure modes we care about (corrupted bundle,
+# missed signature on the main binary). --deep would re-hash every nested
+# Mach-O a second time — not worth the time on CI for ad-hoc builds.
+codesign --verify --strict --verbose=2 "${APP}"

--- a/build-mac.sh
+++ b/build-mac.sh
@@ -202,4 +202,16 @@ done < <(find "${APP}/Contents" -depth \( -name "*.dylib" -o -name "*.framework"
 codesign --force "${RUNTIME_OPTS[@]}" "${ENTITLEMENT_OPTS[@]}" --sign "${SIGN_IDENTITY}" "${APP}"
 
 # Verify the result so a broken bundle fails the build instead of shipping.
-codesign --verify --strict --verbose=2 "${APP}"
+# --deep is deprecated for signing but is still the recommended form for
+# verification: it walks every nested signature instead of relying solely on
+# the outer seal's CodeResources hashes.
+codesign --verify --deep --strict --verbose=2 "${APP}"
+
+# On release builds, also run the full Gatekeeper assessment — the same check
+# the user's Mac performs at first launch. This will fail until the bundle is
+# notarized, so it is informational only (|| true) and skipped on ad-hoc builds
+# where it would always fail.
+if [[ -n "${CERTIFICATE_MACOS_APPLICATION}" ]]; then
+    echo "Running Gatekeeper assessment (informational, pre-notarization):"
+    spctl --assess --type execute --verbose=2 "${APP}" || true
+fi

--- a/build-mac.sh
+++ b/build-mac.sh
@@ -10,12 +10,14 @@ export LIBRARY_PATH=$LIBRARY_PATH:${BREW_PREFIX}/lib:/usr/local/lib:/usr/lib/
 QT_BREW_PATH=$(brew --prefix qt@6)
 CMAKE_FLAGS="-DQt6_DIR=${QT_BREW_PATH}/lib/cmake/Qt6 -DENABLE_NOGUI=false"
 
+# Always disable CMake's POST_BUILD codesign step. Any signature produced there
+# would be invalidated by the framework layout pass below, so we sign once at
+# the end of this script instead.
+CMAKE_FLAGS+=' -DMACOS_CODE_SIGNING="OFF"'
 if [[ -z "${CERTIFICATE_MACOS_APPLICATION}" ]]; then
-    echo "Building without code signing"
-    CMAKE_FLAGS+=' -DMACOS_CODE_SIGNING="OFF"'
+    echo "Building without release code signing (will ad-hoc sign at end)"
 else
-    echo "Building with code signing"
-    CMAKE_FLAGS+=' -DMACOS_CODE_SIGNING="ON"'
+    echo "Building with release code signing (signed at end of script)"
 fi
 
 CMAKE_FLAGS+=' -DCMAKE_POLICY_VERSION_MINIMUM=3.5'
@@ -167,13 +169,37 @@ for paths in file_hashes.values():
 print(f"Replaced duplicates with {linked} symlink(s), freed {freed / 1024 / 1024:.1f} MB")
 PYEOF
 
-# Ad-hoc sign AFTER the layout fix so the signature covers the final bundle
-# state. fixup_bundle modifies Homebrew dylibs (rewriting install names), which
-# invalidates their original signatures; without a fresh signature macOS marks
-# the app as "damaged". A real certificate is used when CERTIFICATE_MACOS_APPLICATION
-# is set; otherwise an ad-hoc signature is enough to satisfy Gatekeeper after a
-# right-click -> Open or via Settings > Privacy.
+# Sign the bundle AFTER the layout fix so the signature covers the final state.
+# fixup_bundle rewrites install names on Homebrew dylibs, which invalidates their
+# original signatures; the layout pass above further modifies the bundle. Without
+# a fresh signature macOS marks the app as "damaged".
+#
+# Signing is done inside-out (Apple's recommended pattern, replacing the now-
+# deprecated --deep flag): every nested .dylib and .framework is signed first
+# (deepest paths first, via `find -depth`), then the outer .app is signed last
+# so its signature seals over the already-signed nested code.
+APP="./build/Binaries/ProjectRio.app"
 if [[ -z "${CERTIFICATE_MACOS_APPLICATION}" ]]; then
-    echo "Ad-hoc signing bundle..."
-    codesign --force --deep --sign - "./build/Binaries/ProjectRio.app"
+    echo "Ad-hoc signing bundle (inside-out)..."
+    SIGN_IDENTITY="-"
+    RUNTIME_OPTS=()
+    ENTITLEMENT_OPTS=()
+else
+    echo "Release signing bundle (inside-out)..."
+    SIGN_IDENTITY="${MACOS_CODE_SIGNING_IDENTITY}"
+    RUNTIME_OPTS=(--options=runtime)
+    ENTITLEMENT_OPTS=(--entitlements "Source/Core/DolphinQt/DolphinEmu.entitlements")
 fi
+
+# Sign nested Mach-O code first (dylibs and frameworks), deepest first.
+while IFS= read -r -d '' item; do
+    codesign --force "${RUNTIME_OPTS[@]}" --sign "${SIGN_IDENTITY}" "${item}"
+done < <(find "${APP}/Contents" -depth \( -name "*.dylib" -o -name "*.framework" \) -print0)
+
+# Sign the outer app last, sealing over the nested signatures. Entitlements are
+# applied only to the main bundle (hardened runtime opts propagate via the
+# nested signatures above).
+codesign --force "${RUNTIME_OPTS[@]}" "${ENTITLEMENT_OPTS[@]}" --sign "${SIGN_IDENTITY}" "${APP}"
+
+# Verify the result so a broken bundle fails the build instead of shipping.
+codesign --verify --strict --verbose=2 "${APP}"


### PR DESCRIPTION
## Summary

### CI / Runner changes
- Replaces the single `macos-14` runner with native `macos-26` (arm64) and `macos-26-intel` (x86_64) runners, restoring proper dual-arch builds on current hardware
- Removes the manual MacOSX SDK download step (no longer needed on current runners)
- Fixes `HOMEBREW_NO_AUTO_UPDATE` so it takes effect before `brew` runs (was previously written to `$GITHUB_ENV`, applying only to later steps)
- Drops the unnecessary `brew upgrade cmake`, which was triggering auto-updates and adding build time
- Adds `ccache` to prerequisites and caches both Homebrew downloads and the ccache directory across CI runs
- Bumps `actions/upload-artifact` from `v2-preview` to `v4`
- Switches macOS artifact format from `.tar.gz` to `.zip` (with `-ry` to preserve symlinks)

### `build-mac.sh` overhaul
- Disables CMake's `POST_BUILD` codesign step — that signature is immediately invalidated by the bundle layout pass below, so signing is deferred to the end of the script
- Adds `ccache` support when available
- Switches from `nproc` to `sysctl -n hw.logicalcpu` (the correct macOS equivalent)
- **Framework dedup / layout fix**: `fixup_bundle` expands every symlink into a full file copy, producing duplicate binaries and an invalid framework layout that Gatekeeper rejects as "damaged". A post-build Python pass restores canonical framework layout (`Versions/Current` symlink + top-level symlinks) and deduplicates content-identical dylib aliases, recovering significant bundle size
- **Ad-hoc codesign (inside-out)**: signs all nested `.dylib`s and `.framework`s first (deepest-first via `find -depth`), then signs the outer `.app` — the pattern Apple recommends as a replacement for `--deep`. All nested items are batched into a single `codesign` call via `xargs` to avoid per-process startup overhead (this was dominating total sign time on the Intel runner)
- Adds post-sign verification (`codesign --verify --strict`) so a broken bundle fails the build rather than shipping

### Bug fix
- Fix UB from calling `pop_back()` on an empty string in the `OnGameMode` tag-parsing path

## Test plan

- [ ] macOS arm64 CI build completes within the 90-minute timeout
- [ ] macOS x86_64 CI build completes within the 90-minute timeout
- [ ] Both macOS artifacts unzip cleanly and `ProjectRio.app` launches without a "damaged" Gatekeeper warning
- [ ] `codesign --verify --strict ProjectRio.app` passes on both artifacts
- [ ] Linux and Windows builds are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)