### PR TITLE
Raise username max length from 21 to 30 characters

### DIFF
--- a/Source/Core/DolphinQt/Config/AddLocalPlayers.cpp
+++ b/Source/Core/DolphinQt/Config/AddLocalPlayers.cpp
@@ -94,10 +94,10 @@ bool AddLocalPlayersEditor::AcceptPlayer()
     return false;
   }
 
-  // checks if the username is too long
-  if (22 <= m_local_player->username.length())
+  // checks if the username is too long (max 30 chars, matches NetPlay MAX_NAME_LENGTH)
+  if (30 < m_local_player->username.length())
   {
-    ModalMessageBox::critical(this, tr("Error"), tr("Username is too long."));
+    ModalMessageBox::critical(this, tr("Error"), tr("Username is too long (max 30 characters)."));
     return false;
   }
 


### PR DESCRIPTION
## Summary

- The previous client-side limit of 21 characters (enforced as `>= 22`) had no documented rationale
- The NetPlay protocol already defines `MAX_NAME_LENGTH = 30` in `NetPlayProto.h`, and the server enforces `> MAX_NAME_LENGTH` on connection — so usernames up to 30 chars already work over NetPlay
- This aligns the Add Local Players dialog validation with that existing protocol limit and updates the error message to be explicit: *"Username is too long (max 30 characters)."*

## Test plan

- [ ] Enter a username of exactly 30 characters — should be accepted
- [ ] Enter a username of 31 characters — should be rejected with the updated error message
- [ ] Confirm existing short usernames still validate and connect to NetPlay normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)