### PR TITLE
Submit ongoing-game updates off the emulation thread

### DIFF
--- a/Source/Core/Core/MSB_StatTracker.cpp
+++ b/Source/Core/Core/MSB_StatTracker.cpp
@@ -12,6 +12,7 @@
 #include "Common/Version.h"
 
 #include "Common/Swap.h"
+#include "Common/Thread.h"
 
 // Package for rendering info on screen
 #include "VideoCommon/OnScreenDisplay.h"
@@ -2190,12 +2191,10 @@ void StatTracker::postOngoingGame(Event& in_curr_event){
     json_stream << "  \"Pitcher\": "                 << std::to_string(in_curr_event.pitcher_roster_loc) << "\n";
     json_stream << "}\n";
 
-    const Common::HttpRequest::Response response =
-        m_http.Post("https://api.projectrio.app/populate_db/ongoing_game/", json_stream.str(),
-            {
-                {"Content-Type", "application/json"},
-            }
-        );
+    // Hand the finished payload off to the background worker so the blocking POST
+    // does not stall the emulation thread. The string is passed by value, so the
+    // worker never touches game state the emulation thread is still mutating.
+    m_ongoing_game_submitter.QueuePost(json_stream.str());
 }
 void StatTracker::updateOngoingGame(Event& in_curr_event){
     if (!shouldSubmitGame()){ return; }
@@ -2295,12 +2294,93 @@ void StatTracker::updateOngoingGame(Event& in_curr_event){
     json_stream << "  }\n";
     json_stream << "}\n";
 
-    const Common::HttpRequest::Response response =
-        m_http.Post("https://api.projectrio.app/populate_db/ongoing_game/", json_stream.str(),
-            {
-                {"Content-Type", "application/json"},
-            }
-        );
+    // Hand the finished payload off to the background worker (see postOngoingGame).
+    m_ongoing_game_submitter.QueueUpdate(json_stream.str());
+}
+
+StatTracker::OngoingGameSubmitter::~OngoingGameSubmitter()
+{
+    {
+        std::lock_guard lg(m_lock);
+        m_shutdown = true;
+    }
+    m_cv.notify_one();
+    if (m_thread.joinable())
+        m_thread.join();
+}
+
+void StatTracker::OngoingGameSubmitter::QueuePost(std::string payload)
+{
+    Enqueue(Item{Kind::Post, std::move(payload)});
+}
+
+void StatTracker::OngoingGameSubmitter::QueueUpdate(std::string payload)
+{
+    Enqueue(Item{Kind::Update, std::move(payload)});
+}
+
+void StatTracker::OngoingGameSubmitter::EnsureThreadStarted()
+{
+    // Lazily start the worker on first use so games that never submit (and the
+    // brief windows where a StatTracker is constructed and torn down) pay nothing.
+    // Caller must hold m_lock.
+    if (!m_thread_started)
+    {
+        m_thread_started = true;
+        m_thread = std::thread(&OngoingGameSubmitter::ThreadLoop, this);
+    }
+}
+
+void StatTracker::OngoingGameSubmitter::Enqueue(Item&& item)
+{
+    std::lock_guard lg(m_lock);
+    if (m_shutdown)
+        return;
+
+    // Coalesce: an update only supersedes an update that is still waiting at the
+    // tail of the queue. The item the worker is currently sending has already been
+    // popped, so it is never affected; a post at the tail is never overwritten or
+    // reordered. This keeps a backlog from a slow request bounded to one pending
+    // update while preserving post-before-update ordering.
+    if (item.kind == Kind::Update && !m_items.empty() && m_items.back().kind == Kind::Update)
+    {
+        m_items.back().payload = std::move(item.payload);
+    }
+    else
+    {
+        m_items.push(std::move(item));
+    }
+
+    EnsureThreadStarted();
+    m_cv.notify_one();
+}
+
+void StatTracker::OngoingGameSubmitter::ThreadLoop()
+{
+    Common::SetCurrentThreadName("RioOngoingGameQueue");
+
+    while (true)
+    {
+        Item item;
+        {
+            std::unique_lock lg(m_lock);
+            m_cv.wait(lg, [&] { return !m_items.empty() || m_shutdown; });
+
+            // On shutdown, stop promptly: discard whatever is still queued instead of
+            // draining it. A request already in flight (popped before m_shutdown was
+            // set) finishes on its own, so teardown is bounded by a single request's
+            // timeout rather than the whole backlog.
+            if (m_shutdown)
+                return;
+
+            item = std::move(m_items.front());
+            m_items.pop();
+        }
+
+        // Blocking POST happens here, off the emulation thread. m_http is owned and
+        // touched only by this thread, so it is never used concurrently.
+        m_http.Post(s_url, item.payload, {{"Content-Type", "application/json"}});
+    }
 }
 
 bool StatTracker::hasEnoughStarsForStarSwing(const Core::CPUThreadGuard& guard, Event& in_event)

--- a/Source/Core/Core/MSB_StatTracker.h
+++ b/Source/Core/Core/MSB_StatTracker.h
@@ -7,6 +7,10 @@
 #include <set>
 #include <tuple>
 #include <iostream>
+#include <queue>
+#include <mutex>
+#include <thread>
+#include <condition_variable>
 #include "Core/HW/Memmap.h"
 #include <picojson.h>
 
@@ -1187,6 +1191,54 @@ public:
     }
 
     Common::HttpRequest m_http{std::chrono::minutes{3}};
+
+    // Sends ongoing-game submissions to the web server on a dedicated background
+    // thread so the blocking HTTP round-trip never stalls the emulation thread.
+    //
+    // The emulation thread builds the JSON payload (cheap) and hands it off via
+    // QueuePost()/QueueUpdate(); the worker owns its own HttpRequest and performs
+    // the blocking POST. "Post" submissions establish the ongoing-game record and
+    // are always sent in order, never dropped. "Update" submissions are full state
+    // snapshots, so if several pile up behind a slow request the worker coalesces
+    // consecutive pending updates down to the newest one. A post is never dropped
+    // or reordered relative to the updates around it.
+    class OngoingGameSubmitter
+    {
+    public:
+        OngoingGameSubmitter() = default;
+        ~OngoingGameSubmitter();
+
+        // Non-blocking. Safe to call from the emulation thread.
+        void QueuePost(std::string payload);
+        void QueueUpdate(std::string payload);
+
+    private:
+        enum class Kind { Post, Update };
+        struct Item
+        {
+            Kind kind = Kind::Update;
+            std::string payload;
+        };
+
+        void EnsureThreadStarted();
+        void Enqueue(Item&& item);
+        void ThreadLoop();
+
+        static constexpr char s_url[] = "https://api.projectrio.app/populate_db/ongoing_game/";
+
+        // Short timeout: these are fire-and-forget telemetry, so a stalled request
+        // should be abandoned quickly rather than holding up later submissions.
+        Common::HttpRequest m_http{std::chrono::seconds{10}};
+
+        std::thread m_thread;
+        std::mutex m_lock;
+        std::condition_variable m_cv;
+        std::queue<Item> m_items;
+        bool m_thread_started = false;
+        bool m_shutdown = false;
+    };
+
+    OngoingGameSubmitter m_ongoing_game_submitter;
 
     //The type of value to decode, the value to be decoded, bool for decode if true or original value if false
     std::string decode(std::string type, u8 value, bool decode);


### PR DESCRIPTION
## Problem

`postOngoingGame()` and `updateOngoingGame()` call `HttpRequest::Post()` synchronously from `StatTracker::Run()`, which runs on the **emulation (CPU) thread** every frame via `ApplyFramePatches()`. `curl_easy_perform()` blocks until the round-trip completes (with a **3-minute** timeout), so any slow or stalled submission freezes emulation — the lag players see. As the ongoing-game endpoint sends more data, each blocking call gets longer.

## Change

Move these fire-and-forget submissions to a dedicated background worker (`OngoingGameSubmitter`). The emulation thread now only builds the JSON payload (cheap) and hands it off via `QueuePost()` / `QueueUpdate()`; the worker owns its **own** `HttpRequest` and performs the blocking POST off-thread, so the network round-trip never stalls emulation.

### Details
- Worker uses a separate `HttpRequest` with a **10s** timeout (vs 3 min) since these are best-effort telemetry.
- `updateOngoingGame` payloads are full state snapshots, so consecutive **pending** updates are **coalesced** (newest wins) to bound a backlog behind a slow request. `postOngoingGame` submissions are **never dropped or reordered**, preserving post-before-update ordering.
- Payloads are passed **by value**, so the worker never reads game state the emulation thread is mutating.
- The two `HttpRequest` objects are never shared across threads.
- On shutdown the worker discards queued items and only lets the in-flight request finish, bounding teardown to a single request timeout.
- The once-per-game **final** `populate_db` submission is intentionally left synchronous (it shows the "do not quit" banner and wants delivery assurance).

This mirrors the existing `AchievementManager` pattern of doing HTTP off a worker thread.

## Scope
- `Source/Core/Core/MSB_StatTracker.h`
- `Source/Core/Core/MSB_StatTracker.cpp`

No new files and no build-system changes.

## Testing
- [ ] Not yet compiled/run by the author in this environment — please build via the normal pipeline before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)