### PR TITLE
CI: pin macOS qtbase to 6.11.0 (qt 6.11.1 fullscreen aspect-ratio regression)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -216,6 +216,28 @@ jobs:
         shell: bash
         run: |
           export HOMEBREW_NO_AUTO_UPDATE=1
+
+          # Pin qtbase to 6.11.0. qtbase 6.11.1 regressed macOS fullscreen handling:
+          # the render window no longer snaps back to the forced 4:3 aspect ratio on a
+          # fullscreen toggle until the window is manually nudged. Homebrew's `qt`
+          # formula is just an umbrella of symlinks; QtGui (where the regression lives)
+          # ships in the separate `qtbase` formula, so we pin qtbase, not qt. `qt`
+          # depends on `qtbase` without a version constraint, so installing 6.11.0 first
+          # satisfies the `qt@6` install below and it won't upgrade qtbase. Other Qt
+          # modules (qtsvg, etc.) stay current — a 6.11.0 qtbase against 6.11.1 modules
+          # builds and runs fine (validated locally). Drop this pin once a qtbase past
+          # 6.11.1 restores the fullscreen behaviour.
+          # homebrew-core commit for qtbase 6.11.0 (bottled): arm64_tahoe + sonoma cover
+          # the macos-26 (arm64) and macos-26-intel (x86_64, via the sonoma fallback) runners.
+          QTBASE_REF="56729e9a19c74be24ba16e2bef7dfa9ab6e07a76"
+          PIN_TAP_DIR="$(brew --repository)/Library/Taps/local/homebrew-qtpin/Formula"
+          mkdir -p "$PIN_TAP_DIR"
+          curl -fsSL "https://raw.githubusercontent.com/Homebrew/homebrew-core/${QTBASE_REF}/Formula/q/qtbase.rb" \
+            -o "$PIN_TAP_DIR/qtbase.rb"
+          brew uninstall --ignore-dependencies qtbase 2>/dev/null || true
+          brew install local/qtpin/qtbase
+          brew pin qtbase
+
           brew install \
             ccache \
             ffmpeg \


### PR DESCRIPTION
## Problem

The macOS release build stopped snapping the render window back to the forced **4:3** aspect ratio when entering/exiting fullscreen — it stays stretched until the window is manually nudged. It surfaced right after PRs #122/#123/#124 merged, but those are **not** the cause.

## Root cause: qtbase 6.11.0 → 6.11.1

Held source constant and flipped only the Qt version (clean rebuilds, since a built `.app` bundles its own Qt frameworks):

| Source | qtbase | Glitch |
|---|---|---|
| pre-PR baseline | 6.11.1 | ❌ yes |
| current branch | 6.11.1 | ❌ yes |
| current branch | 6.11.0 | ✅ no |
| pre-PR baseline | 6.11.0 | ✅ no |

Source is irrelevant; **qtbase 6.11.1** is the only thing that toggles the bug. The merge timing was coincidence — the post-merge CI run was simply the first macOS build to pick up 6.11.1 from floating Homebrew.

Homebrew's `qt` formula is just an umbrella of symlinks; QtGui (where macOS fullscreen/resize handling lives) ships in the separate **`qtbase`** formula — so the fix pins `qtbase`, not `qt`.

## The fix

Pin `qtbase` to 6.11.0 in the macOS `Install prerequisites` step, before `brew install qt@6`:

- `qt` depends on `qtbase` **without** a version constraint, so installing 6.11.0 first satisfies the `qt@6` install and prevents the upgrade.
- Other Qt modules (qtsvg, etc.) stay at 6.11.1 — a 6.11.0 qtbase against 6.11.1 modules builds and runs fine (validated locally on macOS 26 arm64; that's the exact state that produced a working, glitch-free build).
- The pinned 6.11.0 bottle ships `arm64_tahoe` and `sonoma` tags, covering both the `macos-26` (arm64) and `macos-26-intel` (x86_64, via the same sonoma→Tahoe fallback the current 6.11.1 build already uses) runners — no source build.

Scope is macOS only: Windows pins Qt 5.3.0 via Externals, Linux uses distro Qt6 (apt-pinned), SteamOS uses the Flatpak KDE runtime — none float to 6.11.1.

Remove the pin once a qtbase past 6.11.1 restores the fullscreen behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)