### PR TITLE
Enforce 30-char username limit at the input level

### DIFF
--- a/Source/Core/DolphinQt/Config/AddLocalPlayers.cpp
+++ b/Source/Core/DolphinQt/Config/AddLocalPlayers.cpp
@@ -38,6 +38,7 @@ void AddLocalPlayersEditor::SetPlayer(LocalPlayers::LocalPlayers::Player* name)
 void AddLocalPlayersEditor::CreateWidgets()
 {
   m_username_edit = new QLineEdit;
+  m_username_edit->setMaxLength(30);
   m_userid_edit = new QLineEdit;
   m_description = new QLabel(
       tr("\nEnter a Username.\n\n"


### PR DESCRIPTION
## Summary

- PR #122 raised the submission-time validation from 21 → 30 characters to match `MAX_NAME_LENGTH` in `NetPlayProto.h`
- However, the `QLineEdit` input field had no `setMaxLength`, so users could still type unlimited characters before hitting Save
- This adds `m_username_edit->setMaxLength(30)` so the limit is enforced at the UI level — users simply cannot type past 30 characters, making the "too long" error dialog unreachable for this case

Note: the Rio Key field is intentionally not limited — Rio Keys generated via `secrets.token_urlsafe(32)` are 43 characters long.

## Test plan

- [ ] Confirm the username field stops accepting input at 30 characters
- [ ] Confirm the Rio Key field is unaffected and still accepts 43-character keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)