### PR TITLE
Add search bars to Gecko Codes and Texture Pack Manager UIs

### DIFF
--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.cpp
@@ -11,6 +11,7 @@
 #include <QFormLayout>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QLineEdit>
 #include <QListWidget>
 #include <QMenu>
 #include <QPushButton>
@@ -66,6 +67,9 @@ void GeckoCodeWidget::CreateWidgets()
 #ifdef USE_RETRO_ACHIEVEMENTS
   m_hc_warning = new HardcoreWarningWidget(this);
 #endif  // USE_RETRO_ACHIEVEMENTS
+  m_search_box = new QLineEdit;
+  m_search_box->setPlaceholderText(tr("Search codes..."));
+  m_search_box->setClearButtonEnabled(true);
   m_code_list = new QListWidget;
   m_name_label = new QLabel;
   m_creator_label = new QLabel;
@@ -119,6 +123,7 @@ void GeckoCodeWidget::CreateWidgets()
 #ifdef USE_RETRO_ACHIEVEMENTS
   layout->addWidget(m_hc_warning);
 #endif  // USE_RETRO_ACHIEVEMENTS
+  layout->addWidget(m_search_box);
   layout->addWidget(m_code_list);
 
   auto* info_layout = new QFormLayout;
@@ -160,6 +165,7 @@ void GeckoCodeWidget::ConnectWidgets()
   connect(m_code_list, &QListWidget::customContextMenuRequested, this,
           &GeckoCodeWidget::OnContextMenuRequested);
 
+  connect(m_search_box, &QLineEdit::textChanged, this, &GeckoCodeWidget::FilterList);
   connect(m_add_code, &QPushButton::clicked, this, &GeckoCodeWidget::AddCode);
   connect(m_remove_code, &QPushButton::clicked, this, &GeckoCodeWidget::RemoveCode);
   connect(m_edit_code, &QPushButton::clicked, this, &GeckoCodeWidget::EditCode);
@@ -359,7 +365,18 @@ void GeckoCodeWidget::UpdateList()
     }
   }
   m_code_list->setDragDropMode(QAbstractItemView::InternalMove);
+  FilterList(m_search_box->text());
   MakeEnabledList();
+}
+
+void GeckoCodeWidget::FilterList(const QString& text)
+{
+  for (int i = 0; i < m_code_list->count(); i++)
+  {
+    QListWidgetItem* item = m_code_list->item(i);
+    item->setHidden(!text.isEmpty() &&
+                    !item->text().contains(text, Qt::CaseInsensitive));
+  }
 }
 
 void GeckoCodeWidget::DownloadCodes()

--- a/Source/Core/DolphinQt/Config/GeckoCodeWidget.h
+++ b/Source/Core/DolphinQt/Config/GeckoCodeWidget.h
@@ -15,6 +15,7 @@ class CheatWarningWidget;
 class HardcoreWarningWidget;
 #endif  // USE_RETRO_ACHIEVEMENTS
 class QLabel;
+class QLineEdit;
 class QListWidget;
 class QListWidgetItem;
 class QTextEdit;
@@ -44,6 +45,7 @@ private:
   void OnItemChanged(QListWidgetItem* item);
   void OnListReordered();
   void OnContextMenuRequested();
+  void FilterList(const QString& text);
 
   void CreateWidgets();
   void ConnectWidgets();
@@ -67,6 +69,7 @@ private:
 #ifdef USE_RETRO_ACHIEVEMENTS
   HardcoreWarningWidget* m_hc_warning;
 #endif  // USE_RETRO_ACHIEVEMENTS
+  QLineEdit* m_search_box;
   QListWidget* m_code_list;
   QLabel* m_name_label;
   QLabel* m_creator_label;

--- a/Source/Core/DolphinQt/Config/TexturePackManagerDialog.cpp
+++ b/Source/Core/DolphinQt/Config/TexturePackManagerDialog.cpp
@@ -16,6 +16,7 @@
 #include <QGroupBox>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QLineEdit>
 #include <QListWidget>
 #include <QMenu>
 #include <QMessageBox>
@@ -572,6 +573,9 @@ QWidget* TexturePackManagerDialog::BuildTab(Tab& tab, GameTag game)
   auto* available_box = new QGroupBox(tr("Available Packs"));
   available_box->setSizePolicy(pane_size_policy);
   auto* available_layout = new QVBoxLayout;
+  tab.available_search = new QLineEdit;
+  tab.available_search->setPlaceholderText(tr("Search available packs..."));
+  tab.available_search->setClearButtonEnabled(true);
   tab.available_tree = new QTreeWidget;
   tab.available_tree->setHeaderHidden(true);
   tab.available_tree->setSelectionMode(QAbstractItemView::ExtendedSelection);
@@ -582,6 +586,9 @@ QWidget* TexturePackManagerDialog::BuildTab(Tab& tab, GameTag game)
           [this, &tab](const QPoint& p) { OnAvailableContextMenu(tab, p); });
   connect(tab.available_tree, &QTreeWidget::itemDoubleClicked, this,
           [this, &tab](QTreeWidgetItem*, int) { OnAddSelected(tab); });
+  connect(tab.available_search, &QLineEdit::textChanged, this,
+          [this, &tab](const QString& text) { FilterAvailableTree(tab, text); });
+  available_layout->addWidget(tab.available_search);
   available_layout->addWidget(tab.available_tree);
   available_box->setLayout(available_layout);
 
@@ -601,6 +608,9 @@ QWidget* TexturePackManagerDialog::BuildTab(Tab& tab, GameTag game)
   auto* active_box = new QGroupBox(tr("Active Packs (top = highest priority)"));
   active_box->setSizePolicy(pane_size_policy);
   auto* active_layout = new QVBoxLayout;
+  tab.active_search = new QLineEdit;
+  tab.active_search->setPlaceholderText(tr("Search active packs..."));
+  tab.active_search->setClearButtonEnabled(true);
   tab.active_list = new QListWidget;
   tab.active_list->setSelectionMode(QAbstractItemView::ExtendedSelection);
   tab.active_list->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -614,6 +624,9 @@ QWidget* TexturePackManagerDialog::BuildTab(Tab& tab, GameTag game)
           [this, &tab](QListWidgetItem*) { OnRemoveSelected(tab); });
   connect(tab.active_list->model(), &QAbstractItemModel::rowsMoved, this,
           [this] { UpdateInlineNotice(); });
+  connect(tab.active_search, &QLineEdit::textChanged, this,
+          [this, &tab](const QString& text) { FilterActiveList(tab, text); });
+  active_layout->addWidget(tab.active_search);
   active_layout->addWidget(tab.active_list);
 
   auto* active_buttons_layout = new QHBoxLayout;
@@ -702,6 +715,9 @@ void TexturePackManagerDialog::PopulateAvailableTree(Tab& tab)
 
   for (auto& [_, node] : category_nodes)
     node->setHidden(node->childCount() == 0);
+
+  if (!tab.available_search->text().isEmpty())
+    FilterAvailableTree(tab, tab.available_search->text());
 }
 
 void TexturePackManagerDialog::PopulateActiveListFromConfig(Tab& tab)
@@ -738,6 +754,9 @@ void TexturePackManagerDialog::PopulateActiveListFromConfig(Tab& tab)
       item->setForeground(QBrush(palette().color(QPalette::Disabled, QPalette::Text)));
     }
   }
+
+  if (!tab.active_search->text().isEmpty())
+    FilterActiveList(tab, tab.active_search->text());
 }
 
 std::vector<std::string> TexturePackManagerDialog::CurrentActiveOrder(const Tab& tab) const
@@ -764,6 +783,35 @@ void TexturePackManagerDialog::UpdateInlineNotice()
   m_inline_notice->setText(
       tr("Emulation is running. Applying will reload the texture cache so the new pack "
          "order takes effect immediately."));
+}
+
+void TexturePackManagerDialog::FilterAvailableTree(Tab& tab, const QString& text)
+{
+  // Show/hide leaf items based on text match. After updating visibility, hide any category
+  // header whose children are all hidden.
+  for (int i = 0; i < tab.available_tree->topLevelItemCount(); i++)
+  {
+    QTreeWidgetItem* category = tab.available_tree->topLevelItem(i);
+    bool any_visible = false;
+    for (int j = 0; j < category->childCount(); j++)
+    {
+      QTreeWidgetItem* child = category->child(j);
+      const bool match = text.isEmpty() || child->text(0).contains(text, Qt::CaseInsensitive);
+      child->setHidden(!match);
+      if (match)
+        any_visible = true;
+    }
+    category->setHidden(!any_visible);
+  }
+}
+
+void TexturePackManagerDialog::FilterActiveList(Tab& tab, const QString& text)
+{
+  for (int i = 0; i < tab.active_list->count(); i++)
+  {
+    QListWidgetItem* item = tab.active_list->item(i);
+    item->setHidden(!text.isEmpty() && !item->text().contains(text, Qt::CaseInsensitive));
+  }
 }
 
 void TexturePackManagerDialog::OnAddSelected(Tab& tab)

--- a/Source/Core/DolphinQt/Config/TexturePackManagerDialog.h
+++ b/Source/Core/DolphinQt/Config/TexturePackManagerDialog.h
@@ -9,6 +9,7 @@
 
 class ConfigBool;
 class QLabel;
+class QLineEdit;
 class QListWidget;
 class QPushButton;
 class QTabWidget;
@@ -66,7 +67,9 @@ private:
   struct Tab
   {
     GameTag game = GameTag::Baseball;
+    QLineEdit* available_search = nullptr;
     QTreeWidget* available_tree = nullptr;
+    QLineEdit* active_search = nullptr;
     QListWidget* active_list = nullptr;
     QPushButton* add_button = nullptr;
     QPushButton* remove_button = nullptr;
@@ -87,6 +90,8 @@ private:
   // Dialog-level: refreshes the single inline notice based on both tabs' state.
   void UpdateInlineNotice();
 
+  void FilterAvailableTree(Tab& tab, const QString& text);
+  void FilterActiveList(Tab& tab, const QString& text);
   void OnAddSelected(Tab& tab);
   void OnRemoveSelected(Tab& tab);
   void OnMoveUp(Tab& tab);


### PR DESCRIPTION
## Summary

- Adds a live search bar above the code list in the Gecko Codes widget — filters by code name, case-insensitive, with a clear button
- Adds a live search bar above the Available Packs tree in the Texture Pack Manager — filters leaf items and auto-hides empty category headers
- Adds a live search bar above the Active Packs list in the Texture Pack Manager — same case-insensitive filter
- Filter state is preserved across list repopulations (add, remove, refresh, reorder)

## Test plan

- [x] Gecko Codes: open Properties → Gecko Codes, type in search bar — only matching codes visible
- [x] Gecko Codes: clear search — all codes visible again
- [x] Gecko Codes: add/edit/remove a code while search is active — filter re-applies after list refresh
- [x] Texture Pack Manager: type in Available search bar — non-matching packs hidden, empty category headers collapse
- [x] Texture Pack Manager: type in Active search bar — non-matching active packs hidden
- [x] Texture Pack Manager: click Add/Remove/Refresh while search is active — filter re-applies after repopulation
- [x] Both tabs (Baseball / Golf) filter independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)