### PR TITLE
Fix data races on m_desync_detected and netplay_server pointer

### DIFF
--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -1741,6 +1741,7 @@ void NetPlayClient::OnChecksumMsg(sf::Packet& packet)
 
   if (ourChecksum[checksumId] != inChecksum)
   {
+    m_desync_detected = true;
     m_dialog->OnDesync(0, "");
   }
 }

--- a/Source/Core/Core/NetPlayClient.h
+++ b/Source/Core/Core/NetPlayClient.h
@@ -5,6 +5,7 @@
 
 #include <SFML/Network/Packet.hpp>
 #include <array>
+#include <atomic>
 #include <chrono>
 #include <map>
 #include <memory>
@@ -375,7 +376,7 @@ private:
   int framesAsGolfer = 0;
 
   bool m_is_connected = false;
-  bool m_desync_detected = false;
+  std::atomic<bool> m_desync_detected = false;
   ConnectionState m_connection_state = ConnectionState::Failure;
 
   PlayerId m_pid = 0;

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -89,11 +89,15 @@
 
 namespace NetPlay
 {
+static std::mutex crit_netplay_server;
 static NetPlayServer* netplay_server = nullptr;
 
 NetPlayServer::~NetPlayServer()
 {
-  netplay_server = nullptr;
+  {
+    std::lock_guard lk(crit_netplay_server);
+    netplay_server = nullptr;
+  }
   if (is_connected)
   {
     m_do_loop = false;
@@ -171,7 +175,10 @@ NetPlayServer::NetPlayServer(const u16 port, const bool forward_port, NetPlayUI*
   {
     is_connected = true;
     m_do_loop = true;
-    netplay_server = this;
+    {
+      std::lock_guard lk(crit_netplay_server);
+      netplay_server = this;
+    }
     m_thread = std::thread(&NetPlayServer::ThreadFunc, this);
     m_target_buffer_size = 8;
     m_chunked_data_thread = std::thread(&NetPlayServer::ChunkedDataThreadFunc, this);
@@ -2754,6 +2761,7 @@ void NetPlayServer::ChunkedDataAbort()
 
 bool NetPlay_IsDesyncDetected()
 {
+  std::lock_guard lk(crit_netplay_server);
   return (netplay_server && netplay_server->IsDesyncDetected()) ||
          NetPlay_IsClientDesyncDetected();
 }

--- a/Source/Core/Core/NetPlayServer.h
+++ b/Source/Core/Core/NetPlayServer.h
@@ -5,6 +5,7 @@
 
 #include <SFML/Network/Packet.hpp>
 
+#include <atomic>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -200,7 +201,7 @@ private:
   std::map<PlayerId, Client> m_players;
 
   std::unordered_map<u32, std::vector<std::pair<PlayerId, u64>>> m_timebase_by_frame;
-  bool m_desync_detected = false;
+  std::atomic<bool> m_desync_detected = false;
 
   struct
   {


### PR DESCRIPTION
## Summary

- `m_desync_detected` in both `NetPlayServer` and `NetPlayClient` were plain `bool` written on the network thread and read on the emulation thread — undefined behavior. Changed both to `std::atomic<bool>`.
- `netplay_server` static pointer was read in `NetPlay_IsDesyncDetected()` with no lock, creating a TOCTOU use-after-free if the UI thread destroyed `NetPlayServer` concurrently. Added `crit_netplay_server` mutex mirroring the existing `crit_netplay_client` pattern.

## Details

**Bug 4 — `m_desync_detected` data race**
Both fields are written on the network thread and read on the emulation thread (via `NetPlay_IsDesyncDetected()` / `NetPlay_IsClientDesyncDetected()` called from `MSB_StatTracker.cpp`). A plain `bool` offers no cross-thread visibility guarantee — the emulation thread may cache the value indefinitely and keep writing HUD files after a desync. `std::atomic<bool>` fixes this.

Note: `NetPlay_IsClientDesyncDetected()` already holds `crit_netplay_client`, but that lock only protects the `netplay_client` pointer — it does not prevent a concurrent write to `m_desync_detected` inside the object, so the atomic is still needed.

**Bug 5 — `netplay_server` static global race**
`NetPlay_IsDesyncDetected()` reads `netplay_server` and dereferences it in two separate operations with no lock. The UI thread can set `netplay_server = nullptr` (and begin tearing down the object) between the null check and the `->IsDesyncDetected()` call, yielding a use-after-free crash. The fix adds `crit_netplay_server` and wraps all three sites — constructor, destructor, and `NetPlay_IsDesyncDetected()` — exactly as the client already handles `netplay_client`.

## Test plan

- [ ] Verify desync detection still fires correctly in a hosted netplay session
- [ ] Verify HUD file writes stop after a desync is detected
- [x] Run a session through server creation and teardown to exercise the constructor/destructor lock paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)