### PR TITLE
Add more fields to ongoing game initial post

### DIFF
--- a/Source/Core/Core/MSB_StatTracker.cpp
+++ b/Source/Core/Core/MSB_StatTracker.cpp
@@ -2124,7 +2124,7 @@ void StatTracker::postOngoingGame(Event& in_curr_event){
     std::string start_date_time = m_game_info.start_unix_date_time;
     json_stream << "  \"GameID\": \"" << m_game_info.game_id << "\",\n";
     json_stream << "  \"Date - Start\": \"" << start_date_time << "\",\n";
-    
+
     std::string tag_set_id_str = "-1";
     if (m_game_info.tag_set_id.has_value()){
         tag_set_id_str = std::to_string(m_game_info.tag_set_id.value());
@@ -2134,14 +2134,14 @@ void StatTracker::postOngoingGame(Event& in_curr_event){
     json_stream << "  \"StadiumID\": " << decode("Stadium", m_game_info.stadium, false) << ",\n";
     json_stream << "  \"Away Logo\": "  << decode("Logo", m_game_info.away_logo, false) << ",\n";
     json_stream << "  \"Home Logo\": "  << decode("Logo", m_game_info.home_logo, false) << ",\n";
-    json_stream << "  \"Away Player\": \""           << m_game_info.getAwayTeamPlayer().GetUserID() << "\",\n";
-    json_stream << "  \"Home Player\": \""           << m_game_info.getHomeTeamPlayer().GetUserID() << "\",\n";
+    json_stream << "  \"Away Player\": \""  << m_game_info.getAwayTeamPlayer().GetUserID() << "\",\n";
+    json_stream << "  \"Home Player\": \""  << m_game_info.getHomeTeamPlayer().GetUserID() << "\",\n";
 
     u8 away_captain_roster_loc = (m_game_info.away_port == m_game_info.team0_port) ? m_game_info.team0_captain_roster_loc : m_game_info.team1_captain_roster_loc;
     u8 home_captain_roster_loc = (m_game_info.home_port == m_game_info.team0_port) ? m_game_info.team0_captain_roster_loc : m_game_info.team1_captain_roster_loc;
 
-    json_stream << "  \"Away Captain\": "            << std::to_string(away_captain_roster_loc) << ",\n";
-    json_stream << "  \"Home Captain\": "            << std::to_string(home_captain_roster_loc) << ",\n";
+    json_stream << "  \"Away Captain\": " << std::to_string(away_captain_roster_loc) << ",\n";
+    json_stream << "  \"Home Captain\": " << std::to_string(home_captain_roster_loc) << ",\n";
 
     for (int team = 0; team < 2; ++team) {
         std::string team_str = (team == 0) ? "Away" : "Home";
@@ -2168,8 +2168,13 @@ void StatTracker::postOngoingGame(Event& in_curr_event){
         json_stream << "],\n";
     }
 
-    json_stream << "  \"Away Stars\": "              << std::to_string(in_curr_event.away_stars) << ",\n";
-    json_stream << "  \"Home Stars\": "              << std::to_string(in_curr_event.home_stars) << ",\n";
+    json_stream << "  \"Inning\": "       << std::to_string(in_curr_event.inning) << ",\n";
+    json_stream << "  \"Half Inning\": "  << std::to_string(in_curr_event.half_inning) << ",\n";
+    json_stream << "  \"Away Score\": "   << std::dec << in_curr_event.away_score << ",\n";
+    json_stream << "  \"Home Score\": "   << std::dec << in_curr_event.home_score << ",\n";
+    json_stream << "  \"Away Stars\": "   << std::to_string(in_curr_event.away_stars) << ",\n";
+    json_stream << "  \"Home Stars\": "   << std::to_string(in_curr_event.home_stars) << ",\n";
+    json_stream << "  \"Outs\": "         << std::to_string(in_curr_event.outs) << ",\n";
 
     json_stream << "  \"Away Inning Scores\": [";
     for (u8 i = 0; i < in_curr_event.inning && i < 18; ++i) {
@@ -2186,9 +2191,58 @@ void StatTracker::postOngoingGame(Event& in_curr_event){
     }
     json_stream << "],\n";
 
-    json_stream << "  \"Innings Selected\": "        << std::to_string(m_game_info.innings_selected) << ",\n";
-    json_stream << "  \"Star Chance\": "             << std::to_string(in_curr_event.is_star_chance) << ",\n";
-    json_stream << "  \"Pitcher\": "                 << std::to_string(in_curr_event.pitcher_roster_loc) << "\n";
+    json_stream << "  \"Innings Selected\": " << std::to_string(m_game_info.innings_selected) << ",\n";
+    json_stream << "  \"Star Chance\": "      << std::to_string(in_curr_event.is_star_chance) << ",\n";
+    json_stream << "  \"Chemistry Links on Base\": " << std::to_string(in_curr_event.chem_links_ob) << ",\n";
+    json_stream << "  \"Pitcher\": "  << std::to_string(in_curr_event.pitcher_roster_loc) << ",\n";
+    json_stream << "  \"Batter\": "   << std::to_string(in_curr_event.batter_roster_loc) << ",\n";
+
+    int pitcher_team = (in_curr_event.half_inning == 0) ? 1 : 0;
+    int batter_team  = (in_curr_event.half_inning == 0) ? 0 : 1;
+
+    u8 batter_hand = m_game_info.character_summaries[batter_team][in_curr_event.batter_roster_loc].batting_hand;
+    json_stream << "  \"Batter Hand\": " << decode("Hand", batter_hand, false) << ",\n";
+
+    bool runner_1 = (in_curr_event.runner_1.has_value());
+    bool runner_2 = (in_curr_event.runner_2.has_value());
+    bool runner_3 = (in_curr_event.runner_3.has_value());
+    json_stream << "  \"Runner 1B Roster\": " << (runner_1 ? std::to_string(in_curr_event.runner_1.value().roster_loc) : "-1") << ",\n";
+    json_stream << "  \"Runner 2B Roster\": " << (runner_2 ? std::to_string(in_curr_event.runner_2.value().roster_loc) : "-1") << ",\n";
+    json_stream << "  \"Runner 3B Roster\": " << (runner_3 ? std::to_string(in_curr_event.runner_3.value().roster_loc) : "-1") << ",\n";
+
+    EndGameRosterDefensiveStats& p_stat = m_game_info.character_summaries[pitcher_team][in_curr_event.pitcher_roster_loc].end_game_defensive_stats;
+    json_stream << "  \"Pitcher Stats\": {\n";
+    json_stream << "    \"Batters Faced\": "       << std::to_string(p_stat.batters_faced) << ",\n";
+    json_stream << "    \"Runs Allowed\": "        << std::dec << p_stat.runs_allowed << ",\n";
+    json_stream << "    \"Earned Runs\": "         << std::dec << p_stat.earned_runs << ",\n";
+    json_stream << "    \"Batters Walked\": "      << p_stat.batters_walked << ",\n";
+    json_stream << "    \"Batters Hit\": "         << p_stat.batters_hit << ",\n";
+    json_stream << "    \"Hits Allowed\": "        << p_stat.hits_allowed << ",\n";
+    json_stream << "    \"HRs Allowed\": "         << p_stat.homeruns_allowed << ",\n";
+    json_stream << "    \"Pitches Thrown\": "      << p_stat.pitches_thrown << ",\n";
+    json_stream << "    \"Stamina\": "             << p_stat.stamina << ",\n";
+    json_stream << "    \"Strikeouts\": "          << std::to_string(p_stat.strike_outs) << ",\n";
+    json_stream << "    \"Star Pitches Thrown\": " << std::to_string(p_stat.star_pitches_thrown) << ",\n";
+    json_stream << "    \"Outs Pitched\": "        << std::to_string(p_stat.outs_pitched) << "\n";
+    json_stream << "  },\n";
+
+    EndGameRosterOffensiveStats& b_stat = m_game_info.character_summaries[batter_team][in_curr_event.batter_roster_loc].end_game_offensive_stats;
+    json_stream << "  \"Batter Stats\": {\n";
+    json_stream << "    \"At Bats\": "          << std::to_string(b_stat.at_bats) << ",\n";
+    json_stream << "    \"Hits\": "             << std::to_string(b_stat.hits) << ",\n";
+    json_stream << "    \"Singles\": "          << std::to_string(b_stat.singles) << ",\n";
+    json_stream << "    \"Doubles\": "          << std::to_string(b_stat.doubles) << ",\n";
+    json_stream << "    \"Triples\": "          << std::to_string(b_stat.triples) << ",\n";
+    json_stream << "    \"Homeruns\": "         << std::to_string(b_stat.homeruns) << ",\n";
+    json_stream << "    \"Successful Bunts\": " << std::to_string(b_stat.successful_bunts) << ",\n";
+    json_stream << "    \"Sac Flys\": "         << std::to_string(b_stat.sac_flys) << ",\n";
+    json_stream << "    \"Strikeouts\": "       << std::to_string(b_stat.strikouts) << ",\n";
+    json_stream << "    \"Walks (4 Balls)\": "  << std::to_string(b_stat.walks_4balls) << ",\n";
+    json_stream << "    \"Walks (Hit)\": "      << std::to_string(b_stat.walks_hit) << ",\n";
+    json_stream << "    \"RBI\": "              << std::to_string(b_stat.rbi) << ",\n";
+    json_stream << "    \"Bases Stolen\": "     << std::to_string(b_stat.bases_stolen) << ",\n";
+    json_stream << "    \"Star Hits\": "        << std::to_string(b_stat.star_hits) << "\n";
+    json_stream << "  }\n";
     json_stream << "}\n";
 
     // Hand the finished payload off to the background worker so the blocking POST

--- a/Source/Core/Core/MSB_StatTracker.cpp
+++ b/Source/Core/Core/MSB_StatTracker.cpp
@@ -241,7 +241,13 @@ void StatTracker::lookForTriggerEvents(const Core::CPUThreadGuard& guard)
                 if (PowerPC::MMU::HostRead_U8(guard, aGameControlStateCurr) == 0xb){
                     std::cout << "Game paused, need to re-init event " << std::to_string(m_game_info.event_num) << "\n";
                     logGameInfo(guard);
-                    updateOngoingGame(m_game_info.getCurrentEvent());
+
+                    // if there's a pause before the first pitch, do not run the update function since the initial post of the ongoing game hasn't happened yet.
+                    if (m_game_info.post_ongoing_game == false)
+                    {
+                        updateOngoingGame(m_game_info.getCurrentEvent());
+                    }
+                    
                     m_event_state = EVENT_STATE::INIT_EVENT;
                 }
                 //Watch for Runners Stealing

--- a/Source/Core/Core/MSB_StatTracker.cpp
+++ b/Source/Core/Core/MSB_StatTracker.cpp
@@ -2194,8 +2194,8 @@ void StatTracker::postOngoingGame(Event& in_curr_event){
     json_stream << "  \"Innings Selected\": " << std::to_string(m_game_info.innings_selected) << ",\n";
     json_stream << "  \"Star Chance\": "      << std::to_string(in_curr_event.is_star_chance) << ",\n";
     json_stream << "  \"Chemistry Links on Base\": " << std::to_string(in_curr_event.chem_links_ob) << ",\n";
-    json_stream << "  \"Pitcher\": "  << std::to_string(in_curr_event.pitcher_roster_loc) << ",\n";
-    json_stream << "  \"Batter\": "   << std::to_string(in_curr_event.batter_roster_loc) << ",\n";
+    json_stream << "  \"Pitcher Roster Loc\": "  << std::to_string(in_curr_event.pitcher_roster_loc) << ",\n";
+    json_stream << "  \"Batter Roster Loc\": "   << std::to_string(in_curr_event.batter_roster_loc) << ",\n";
 
     int pitcher_team = (in_curr_event.half_inning == 0) ? 1 : 0;
     int batter_team  = (in_curr_event.half_inning == 0) ? 0 : 1;
@@ -2265,8 +2265,8 @@ void StatTracker::updateOngoingGame(Event& in_curr_event){
     json_stream << "  \"Away Stars\": "              << std::to_string(in_curr_event.away_stars) << ",\n";
     json_stream << "  \"Home Stars\": "              << std::to_string(in_curr_event.home_stars) << ",\n";
     json_stream << "  \"Chemistry Links on Base\": " << std::to_string(in_curr_event.chem_links_ob) << ",\n";
-    json_stream << "  \"Pitcher\": "      << std::to_string(in_curr_event.pitcher_roster_loc) << ",\n";
-    json_stream << "  \"Batter\": "       << std::to_string(in_curr_event.batter_roster_loc) << ",\n";
+    json_stream << "  \"Pitcher Roster Loc\": "      << std::to_string(in_curr_event.pitcher_roster_loc) << ",\n";
+    json_stream << "  \"Batter Roster Loc\": "       << std::to_string(in_curr_event.batter_roster_loc) << ",\n";
 
     int batter_team_for_hand = (in_curr_event.half_inning == 0) ? 0 : 1;
     u8 batter_hand = m_game_info.character_summaries[batter_team_for_hand][in_curr_event.batter_roster_loc].batting_hand;


### PR DESCRIPTION
Replaces PR129 with an additional fix to guard the update ongoing games before the post is initialized. 