### PR TITLE
Bug fixes0601

### DIFF
--- a/Source/Core/Core/GeckoCodeConfig.cpp
+++ b/Source/Core/Core/GeckoCodeConfig.cpp
@@ -146,10 +146,15 @@ std::vector<GeckoCode> LoadCodes(const Common::IniFile& globalIni, const Common:
     std::optional<std::string> BuiltInGeckoCodes;
     if (gameId == "GYQE01")
     {
+      // Honor the local options for local play and the netplay-synced options for netplay; the two
+      // sets are kept separate so a persisted local setting can never leak into a netplay match.
+      const bool night_stadium = is_netplay ? isNightStadiumNetplay : isNightStadiumLocal;
+      const bool disable_replays = is_netplay ? isDisableReplaysNetplay : isDisableReplaysLocal;
+
       BuiltInGeckoCodes = MSSB_BuiltInGeckoCodes;
-      if (isNightStadium)
+      if (night_stadium)
         BuiltInGeckoCodes = BuiltInGeckoCodes.value() + MSSB_NightStadium;
-      if (isDisableReplays)
+      if (disable_replays)
         BuiltInGeckoCodes = BuiltInGeckoCodes.value() + MSSB_DisableReplays;
     }
     // else if (gameId == "GFTE01")
@@ -339,16 +344,32 @@ void ReadLines(std::vector<GeckoCode>& gcodes, std::vector<std::string>& lines, 
   }
 }
 
-bool isNightStadium = false;
-void setNightStadium(bool is_night)
+bool isNightStadiumLocal = false;
+bool isNightStadiumNetplay = false;
+void setNightStadiumLocal(bool is_night)
 {
-  isNightStadium = is_night;
+  isNightStadiumLocal = is_night;
+}
+void setNightStadiumNetplay(bool is_night)
+{
+  isNightStadiumNetplay = is_night;
 }
 
-bool isDisableReplays = false;
-void setDisableReplays(bool disable)
+bool isDisableReplaysLocal = false;
+bool isDisableReplaysNetplay = false;
+void setDisableReplaysLocal(bool disable)
 {
-  isDisableReplays = disable;
+  isDisableReplaysLocal = disable;
+}
+void setDisableReplaysNetplay(bool disable)
+{
+  isDisableReplaysNetplay = disable;
+}
+
+void resetNetplayGameOptions()
+{
+  isNightStadiumNetplay = false;
+  isDisableReplaysNetplay = false;
 }
 
 bool isLoadingFromHUD = false;

--- a/Source/Core/Core/GeckoCodeConfig.h
+++ b/Source/Core/Core/GeckoCodeConfig.h
@@ -26,11 +26,23 @@ void SaveCodes(Common::IniFile& inifile, const std::vector<GeckoCode>& gcodes);
 std::optional<GeckoCode::Code> DeserializeLine(const std::string& line);
 void ReadLines(std::vector<GeckoCode>& gcodes, std::vector<std::string>& lines, bool user_defined);
 
-extern bool isNightStadium;
-void setNightStadium(bool is_night);
+// Night Mario Stadium / Disable Replays are exposed both in local play (via the Local Players
+// widget) and in netplay (host-controlled, synced to clients). The two contexts are kept in
+// completely separate state so a persisted local setting can never leak into a netplay match and
+// cause a desync. LoadCodes() selects which set to honor based on its is_netplay argument.
+extern bool isNightStadiumLocal;
+extern bool isNightStadiumNetplay;
+void setNightStadiumLocal(bool is_night);
+void setNightStadiumNetplay(bool is_night);
 
-extern bool isDisableReplays;
-void setDisableReplays(bool disable);
+extern bool isDisableReplaysLocal;
+extern bool isDisableReplaysNetplay;
+void setDisableReplaysLocal(bool disable);
+void setDisableReplaysNetplay(bool disable);
+
+// Resets the netplay-only options to their defaults (off). Called at the start of a netplay
+// session so a previous session's state can't carry over before the host syncs values.
+void resetNetplayGameOptions();
 
 extern bool isLoadingFromHUD;
 extern MSBQuickMatchGameState HUDState;

--- a/Source/Core/Core/MSB_HUDStateLoader.cpp
+++ b/Source/Core/Core/MSB_HUDStateLoader.cpp
@@ -322,11 +322,11 @@ bool LoadStateFromHud(const std::string& path, MSBQuickMatchGameState& outState,
         else
             state.p2TeamStars = awayStars;
     }
-    INFO_LOG_FMT(COMMON, "Away Stars assigned to P{}: {}", 
-        p1IsAway ? 
-            (state.p1TeamStars.has_value() ? std::to_string(state.p1TeamStars.value()) : "not set") : 
-            (state.p2TeamStars.has_value() ? std::to_string(state.p2TeamStars.value()) : "not set"),
-        p1IsAway ? "1" : "2");
+    INFO_LOG_FMT(COMMON, "Away Stars assigned to P{}: {}",
+        p1IsAway ? "1" : "2",
+        p1IsAway ?
+            (state.p1TeamStars.has_value() ? std::to_string(state.p1TeamStars.value()) : "not set") :
+            (state.p2TeamStars.has_value() ? std::to_string(state.p2TeamStars.value()) : "not set"));
 
     if (j.count("Home Stars"))
     {
@@ -336,11 +336,11 @@ bool LoadStateFromHud(const std::string& path, MSBQuickMatchGameState& outState,
         else
             state.p1TeamStars = homeStars;
     }
-    INFO_LOG_FMT(COMMON, "Home Stars assigned to P{}: {}", 
-        p1IsAway ? 
-            (state.p2TeamStars.has_value() ? std::to_string(state.p2TeamStars.value()) : "not set") : 
-            (state.p1TeamStars.has_value() ? std::to_string(state.p1TeamStars.value()) : "not set"),
-        p1IsAway ? "2" : "1");
+    INFO_LOG_FMT(COMMON, "Home Stars assigned to P{}: {}",
+        p1IsAway ? "2" : "1",
+        p1IsAway ?
+            (state.p2TeamStars.has_value() ? std::to_string(state.p2TeamStars.value()) : "not set") :
+            (state.p1TeamStars.has_value() ? std::to_string(state.p1TeamStars.value()) : "not set"));
 
     if (j.count("Star Chance"))
         state.isStarChance = static_cast<uint8_t>(j.at("Star Chance").get<double>());

--- a/Source/Core/Core/MSB_HUDStateLoader.cpp
+++ b/Source/Core/Core/MSB_HUDStateLoader.cpp
@@ -71,27 +71,34 @@ bool LoadStateFromHud(const std::string& path, MSBQuickMatchGameState& outState,
         return false;
     }
 
-    // If opponent is known, validate they match the other slot
-    if (!p2Username.empty())
-    {
-        bool opponentIsAway = (p2Username == awayPlayer);
-        bool opponentIsHome = (p2Username == homePlayer);
+    // Validate the opponent slot (the one P1 doesn't occupy) every time. A CPU opponent is recorded
+    // in the HUD as the literal "CPU", while locally it appears as an empty p2Username (Player 2 =
+    // "No Player Selected"); treat those as equivalent so a CPU game validates against a CPU game,
+    // but still reject a CPU-vs-human mismatch in either direction.
+    const std::string hudOpponent = p1IsAway ? homePlayer : awayPlayer;
+    const bool hudOpponentIsCpu = (hudOpponent == "CPU" || hudOpponent == "No Player Selected");
+    const bool localOpponentIsCpu = p2Username.empty();
 
-        if (!((p1IsAway && opponentIsHome) || (p1IsHome && opponentIsAway)))
+    if (hudOpponentIsCpu || localOpponentIsCpu)
+    {
+        if (hudOpponentIsCpu != localOpponentIsCpu)
         {
-            ERROR_LOG_FMT(COMMON, "Player mismatch. P1='{}', Opponent='{}', HUD Away='{}', HUD Home='{}'",
-                        p1Username, p2Username, awayPlayer, homePlayer);
+            ERROR_LOG_FMT(COMMON,
+                "Player mismatch (CPU). P1='{}', Local Opponent='{}', HUD Away='{}', HUD Home='{}'",
+                p1Username, p2Username.empty() ? "CPU" : p2Username, awayPlayer, homePlayer);
             return false;
         }
-
-        menuInputRestrictionEnabled = true; // if both players present, restrict menu inputs to prevent accidental desync. 
     }
-    // Solo game - just verify P1 player is in the file, P2 slot can be "No Player Selected"
-    else
+    else if (hudOpponent != p2Username)
     {
-        menuInputRestrictionEnabled = false; // if solo, don't restrict menu inputs since P1 needs some control on the captain screen. Used for debugging.
-        INFO_LOG_FMT(COMMON, "Solo game detected, skipping opponent validation.");
+        ERROR_LOG_FMT(COMMON, "Player mismatch. P1='{}', Opponent='{}', HUD Away='{}', HUD Home='{}'",
+                    p1Username, p2Username, awayPlayer, homePlayer);
+        return false;
     }
+
+    // Restrict menu inputs only when a human opponent is present; a CPU game leaves P1 free to
+    // control the captain screen.
+    menuInputRestrictionEnabled = !localOpponentIsCpu;
 
     INFO_LOG_FMT(COMMON, "Starting parsing HUD to fill out state");
 
@@ -583,18 +590,29 @@ int allowLoadFromHUD(const std::string& path,
         return 4;
     }
 
-    // If opponent is known, validate they match the other slot
-    if (!p2Username.empty())
-    {
-        bool opponentIsAway = (p2Username == awayPlayer);
-        bool opponentIsHome = (p2Username == homePlayer);
+    // Validate the opponent slot (the one P1 doesn't occupy) every time. A CPU opponent is recorded
+    // in the HUD as the literal "CPU", while locally it appears as an empty p2Username (Player 2 =
+    // "No Player Selected"); treat those as equivalent so a CPU game validates against a CPU game,
+    // but still reject a CPU-vs-human mismatch in either direction.
+    const std::string hudOpponent = p1IsAway ? homePlayer : awayPlayer;
+    const bool hudOpponentIsCpu = (hudOpponent == "CPU" || hudOpponent == "No Player Selected");
+    const bool localOpponentIsCpu = p2Username.empty();
 
-        if (!((p1IsAway && opponentIsHome) || (p1IsHome && opponentIsAway)))
+    if (hudOpponentIsCpu || localOpponentIsCpu)
+    {
+        if (hudOpponentIsCpu != localOpponentIsCpu)
         {
-            ERROR_LOG_FMT(COMMON, "Player mismatch. P1='{}', Opponent='{}', HUD Away='{}', HUD Home='{}'",
-                        p1Username, p2Username, awayPlayer, homePlayer);
+            ERROR_LOG_FMT(COMMON,
+                "Player mismatch (CPU). P1='{}', Local Opponent='{}', HUD Away='{}', HUD Home='{}'",
+                p1Username, p2Username.empty() ? "CPU" : p2Username, awayPlayer, homePlayer);
             return 4;
         }
+    }
+    else if (hudOpponent != p2Username)
+    {
+        ERROR_LOG_FMT(COMMON, "Player mismatch. P1='{}', Opponent='{}', HUD Away='{}', HUD Home='{}'",
+                    p1Username, p2Username, awayPlayer, homePlayer);
+        return 4;
     }
 
     INFO_LOG_FMT(COMMON, "All checks passed. HUD can load.");

--- a/Source/Core/Core/MSB_StatTracker.cpp
+++ b/Source/Core/Core/MSB_StatTracker.cpp
@@ -1838,7 +1838,11 @@ void StatTracker::initPlayerInfo(const Core::CPUThreadGuard& guard){
         m_game_info.team1_port = ports[1];
 
         //Need to acount for possibility to init during the bottom of the inning if the fast load mod is on.
-        if (m_game_info.getCurrentEvent().half_inning == 0)
+        //Read half_inning from live memory here: initPlayerInfo runs before logEventState populates
+        //the current event's half_inning, so the event field is still stale (default 0) at this point.
+        //BattingPort/FieldingPort above are live reads, so half_inning must be too or away/home flip.
+        u8 half_inning = PowerPC::MMU::HostRead_U8(guard, aAB_HalfInning);
+        if (half_inning == 0)
         {
             m_game_info.home_port = FieldingPort;
             m_game_info.away_port = BattingPort;

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -1651,7 +1651,7 @@ void NetPlayClient::OnNightMsg(sf::Packet& packet)
   bool is_night;
   packet >> is_night;
   m_dialog->OnNightResult(is_night);
-  Gecko::setNightStadium(is_night);
+  Gecko::setNightStadiumNetplay(is_night);
 }
 
 void NetPlayClient::OnDisableReplaysMsg(sf::Packet& packet)
@@ -1659,7 +1659,7 @@ void NetPlayClient::OnDisableReplaysMsg(sf::Packet& packet)
   bool disable;
   packet >> disable;
   m_dialog->OnDisableReplaysResult(disable);
-  Gecko::setDisableReplays(disable);
+  Gecko::setDisableReplaysNetplay(disable);
 }
 
 void NetPlayClient::OnFastResetFromHUDMsg(sf::Packet& packet)

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -140,6 +140,11 @@ NetPlayServer::NetPlayServer(const u16 port, const bool forward_port, NetPlayUI*
   m_gba_config.fill({});
   m_wiimote_map.fill(0);
 
+  // Clear any netplay game options left over from a previous session in this process so a stale
+  // value can't apply before the host toggles/syncs them. The host's per-session checkbox state
+  // drives these via AdjustNightStadium/AdjustReplays.
+  Gecko::resetNetplayGameOptions();
+
   if (traversal_config.use_traversal)
   {
     if (!Common::EnsureTraversalClient(traversal_config.traversal_host,
@@ -724,6 +729,10 @@ void NetPlayServer::AdjustNightStadium(const bool is_night)
   std::lock_guard lkg(m_crit.game);
   m_current_night_value = is_night;
 
+  // Apply on the host directly so the code-sync build (LoadCodes with is_netplay=true) reads the
+  // correct value without depending on the host's loopback client processing the broadcast first.
+  Gecko::setNightStadiumNetplay(is_night);
+
   // tell clients to change night stadium
   sf::Packet spac;
   spac << MessageID::NightStadium;
@@ -736,6 +745,10 @@ void NetPlayServer::AdjustReplays(const bool disable)
 {
   std::lock_guard lkg(m_crit.game);
   m_current_disable_replays_value = disable;
+
+  // Apply on the host directly so the code-sync build (LoadCodes with is_netplay=true) reads the
+  // correct value without depending on the host's loopback client processing the broadcast first.
+  Gecko::setDisableReplaysNetplay(disable);
 
   // tell clients to change disable replays
   sf::Packet spac;
@@ -2306,9 +2319,11 @@ bool NetPlayServer::SyncCodes()
   // Sync Gecko Codes
   {
 
-    // Create a Gecko Code Vector with just the active codes
+    // Create a Gecko Code Vector with just the active codes.
+    // This runs on the host during a netplay session, so load with is_netplay=true to honor the
+    // netplay-synced game options rather than the host's local-play settings.
     std::vector<Gecko::GeckoCode> s_active_codes =
-        Gecko::SetAndReturnActiveCodes(Gecko::LoadCodes(globalIni, localIni, game_id, false));
+        Gecko::SetAndReturnActiveCodes(Gecko::LoadCodes(globalIni, localIni, game_id, true));
 
     // Determine Codelist Size
     u16 codelines = 0;

--- a/Source/Core/DolphinQt/Config/LocalPlayersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/LocalPlayersWidget.cpp
@@ -491,8 +491,8 @@ void LocalPlayersWidget::OnEmulationStateChanged(Core::State state)
     // Re-apply local game options only after the netplay session ends, not between games.
     if (!NetPlay::IsNetPlayRunning())
     {
-      Gecko::setNightStadium(m_night_stadium->isChecked());
-      Gecko::setDisableReplays(m_disable_replays->isChecked());
+      Gecko::setNightStadiumLocal(m_night_stadium->isChecked());
+      Gecko::setDisableReplaysLocal(m_disable_replays->isChecked());
     }
   }
 }
@@ -517,8 +517,8 @@ void LocalPlayersWidget::LoadLocalGameOptions()
   m_night_stadium->blockSignals(false);
   m_disable_replays->blockSignals(false);
 
-  Gecko::setNightStadium(nightStadium);
-  Gecko::setDisableReplays(disableReplays);
+  Gecko::setNightStadiumLocal(nightStadium);
+  Gecko::setDisableReplaysLocal(disableReplays);
 }
 
 void LocalPlayersWidget::SaveLocalGameOptions()
@@ -572,12 +572,12 @@ void LocalPlayersWidget::ConnectWidgets()
           &LocalPlayersWidget::ValidateAndApplyFastReset);
 
   connect(m_night_stadium, &QCheckBox::stateChanged, this, [this]() {
-    Gecko::setNightStadium(m_night_stadium->isChecked());
+    Gecko::setNightStadiumLocal(m_night_stadium->isChecked());
     SaveLocalGameOptions();
   });
 
   connect(m_disable_replays, &QCheckBox::stateChanged, this, [this]() {
-    Gecko::setDisableReplays(m_disable_replays->isChecked());
+    Gecko::setDisableReplaysLocal(m_disable_replays->isChecked());
     SaveLocalGameOptions();
   });
 

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -806,6 +806,16 @@ void NetPlayDialog::show(bool use_traversal)
   m_fast_reset_from_HUD->setHidden(!is_hosting);
   m_fast_reset_from_HUD->setEnabled(is_hosting);
 
+  // Start each netplay session with these host options off so a previous session's checkbox state
+  // can't linger out of sync with the (reset) Gecko netplay flags. Signals are blocked because no
+  // server/client may exist yet and we don't want to fire the broadcast handlers here.
+  m_night_stadium->blockSignals(true);
+  m_disable_replays->blockSignals(true);
+  m_night_stadium->setChecked(false);
+  m_disable_replays->setChecked(false);
+  m_night_stadium->blockSignals(false);
+  m_disable_replays->blockSignals(false);
+
   UpdateLobbyLayout();
   SetOptionsEnabled(true);
 


### PR DESCRIPTION
Fixes local gecko code issue interfering with netplay.
CPU bypass taken away, so fast reset will always validate players match.
Fix port assigning issue when fast resetting into the bottom of the inning and the half inning being uninitialized.